### PR TITLE
Add local time offset to date_i18n() param

### DIFF
--- a/includes/special-mail-tags.php
+++ b/includes/special-mail-tags.php
@@ -42,6 +42,10 @@ function wpcf7_special_mail_tag( $output, $name, $html ) {
 	if ( '_date' == $name
 	or '_time' == $name ) {
 		if ( $timestamp = $submission->get_meta( 'timestamp' ) ) {
+
+			// Temporary fix until introducing wp_date()
+			$timestamp += get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
+
 			if ( '_date' == $name ) {
 				return date_i18n( get_option( 'date_format' ), $timestamp );
 			}


### PR DESCRIPTION
See #17

Note that you have to pass `$timestamp_with_offset` to [`date_i18n()`](https://developer.wordpress.org/reference/functions/date_i18n/).