### PR TITLE
Exclude functional variables from posted_data

### DIFF
--- a/includes/submission.php
+++ b/includes/submission.php
@@ -139,8 +139,10 @@ class WPCF7_Submission {
 	}
 
 	private function setup_posted_data() {
-		$posted_data = (array) $_POST;
-		$posted_data = array_diff_key( $posted_data, array( '_wpnonce' => '' ) );
+		$posted_data = array_filter( (array) $_POST, function( $key ) {
+			return '_' !== substr( $key, 0, 1 );
+		}, ARRAY_FILTER_USE_KEY );
+
 		$posted_data = wp_unslash( $posted_data );
 		$posted_data = $this->sanitize_posted_data( $posted_data );
 
@@ -154,6 +156,11 @@ class WPCF7_Submission {
 			$type = $tag->type;
 			$name = $tag->name;
 			$pipes = $tag->pipes;
+
+			if ( wpcf7_form_tag_supports( $type, 'do-not-store' ) ) {
+				unset( $posted_data[$name] );
+				continue;
+			}
 
 			$value_orig = $value = '';
 

--- a/modules/flamingo.php
+++ b/modules/flamingo.php
@@ -35,22 +35,6 @@ function wpcf7_flamingo_submit( $contact_form, $result ) {
 		return;
 	}
 
-	$fields_senseless =
-		$contact_form->scan_form_tags( array( 'feature' => 'do-not-store' ) );
-
-	$exclude_names = array();
-
-	foreach ( $fields_senseless as $tag ) {
-		$exclude_names[] = $tag['name'];
-	}
-
-	foreach ( $posted_data as $key => $value ) {
-		if ( '_' == substr( $key, 0, 1 )
-		or in_array( $key, $exclude_names ) ) {
-			unset( $posted_data[$key] );
-		}
-	}
-
 	$email = wpcf7_flamingo_get_value( 'email', $contact_form );
 	$name = wpcf7_flamingo_get_value( 'name', $contact_form );
 	$subject = wpcf7_flamingo_get_value( 'subject', $contact_form );


### PR DESCRIPTION
To guarantee only normal variables that are available in messages are in `posted_data`. Use `$_POST` for other purposes like input validation.

See #57