### PR TITLE
Rename to wpcf7_contact_forms_per_page

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -166,11 +166,11 @@ function wpcf7_dark_mode_support( $user_id ) {
 }
 
 add_filter( 'set-screen-option', 'wpcf7_set_screen_options', 10, 3 );
-add_filter( 'set_screen_option_cfseven_contact_forms_per_page', 'wpcf7_set_screen_options', 10, 3 );
+add_filter( 'set_screen_option_wpcf7_contact_forms_per_page', 'wpcf7_set_screen_options', 10, 3 );
 
 function wpcf7_set_screen_options( $result, $option, $value ) {
 	$wpcf7_screens = array(
-		'cfseven_contact_forms_per_page',
+		'wpcf7_contact_forms_per_page',
 	);
 
 	if ( in_array( $option, $wpcf7_screens ) ) {
@@ -350,7 +350,7 @@ function wpcf7_load_contact_form_admin() {
 
 		add_screen_option( 'per_page', array(
 			'default' => 20,
-			'option' => 'cfseven_contact_forms_per_page',
+			'option' => 'wpcf7_contact_forms_per_page',
 		) );
 	}
 }

--- a/admin/includes/class-contact-forms-list-table.php
+++ b/admin/includes/class-contact-forms-list-table.php
@@ -28,7 +28,7 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 
 	public function prepare_items() {
 		$current_screen = get_current_screen();
-		$per_page = $this->get_items_per_page( 'cfseven_contact_forms_per_page' );
+		$per_page = $this->get_items_per_page( 'wpcf7_contact_forms_per_page' );
 
 		$args = array(
 			'posts_per_page' => $per_page,


### PR DESCRIPTION
Just for consistency. It was using the `cfseven` prefix because you used to be not able to use a numeric character in the name of a key in old WordPress. Maybe.

See #70