### PR TITLE
Introduce $posted_data_hash and $skip_spam_check properties

### DIFF
--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -452,6 +452,7 @@ class WPCF7_ContactForm {
 			'_wpcf7_locale' => $this->locale(),
 			'_wpcf7_unit_tag' => $this->unit_tag(),
 			'_wpcf7_container_post' => 0,
+			'_wpcf7_posted_data_hash' => '',
 		);
 
 		if ( in_the_loop() ) {
@@ -760,6 +761,7 @@ class WPCF7_ContactForm {
 			'status' => $submission->get_status(),
 			'message' => $submission->get_response(),
 			'demo_mode' => $this->in_demo_mode(),
+			'posted_data_hash' => $submission->get_posted_data_hash(),
 		);
 
 		if ( $submission->is( 'validation_failed' ) ) {

--- a/includes/js/scripts.js
+++ b/includes/js/scripts.js
@@ -296,6 +296,11 @@
 
 				$response.attr( 'role', 'alert' ).focus();
 			} );
+
+			if ( data.postedDataHash ) {
+				$form.find( 'input[name="_wpcf7_posted_data_hash"]' ).first()
+					.val( data.postedDataHash );
+			}
 		};
 
 		$.ajax( {

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -290,6 +290,7 @@ function wpcf7_rest_create_feedback( WP_REST_Request $request ) {
 		'into' => '#' . wpcf7_sanitize_unit_tag( $unit_tag ),
 		'status' => $result['status'],
 		'message' => $result['message'],
+		'postedDataHash' => $result['posted_data_hash'],
 	);
 
 	if ( 'validation_failed' == $result['status'] ) {


### PR DESCRIPTION
Generate a hash based on `$posted_data` after spam verification. Having a hash identical to one from a past submission means the current submission is identical to the past one and it has once passed through a spam verification (has confirmed it is not spam), so you can skip spam check safely this time. This avoids to apply unnecessary spam checks to submissions that are safe in reality.

See #57