### PR TITLE
Use snake case in REST API responses

### DIFF
--- a/admin/js/scripts.js
+++ b/admin/js/scripts.js
@@ -85,7 +85,7 @@
 				},
 				data: data
 			} ).done( function( response ) {
-				wpcf7.configValidator.errors = response.configErrors;
+				wpcf7.configValidator.errors = response.config_errors;
 				wpcf7.updateConfigErrors();
 			} );
 		} );

--- a/includes/js/scripts.js
+++ b/includes/js/scripts.js
@@ -204,7 +204,7 @@
 					wpcf7.setStatus( $form, 'init' );
 					break;
 				case 'validation_failed':
-					$.each( data.invalidFields, function( i, n ) {
+					$.each( data.invalid_fields, function( i, n ) {
 						$( n.into, $form ).each( function() {
 							wpcf7.notValidTip( this, n.message );
 							$( '.wpcf7-form-control', this ).addClass( 'wpcf7-not-valid' );
@@ -267,10 +267,10 @@
 				var $response = $( this );
 				$response.html( '' ).append( data.message );
 
-				if ( data.invalidFields ) {
+				if ( data.invalid_fields ) {
 					var $invalids = $( '<ul></ul>' );
 
-					$.each( data.invalidFields, function( i, n ) {
+					$.each( data.invalid_fields, function( i, n ) {
 						if ( n.idref ) {
 							var $li = $( '<li></li>' ).append( $( '<a></a>' ).attr( 'href', '#' + n.idref ).append( n.message ) );
 						} else {
@@ -286,9 +286,9 @@
 				$response.focus();
 			} );
 
-			if ( data.postedDataHash ) {
+			if ( data.posted_data_hash ) {
 				$form.find( 'input[name="_wpcf7_posted_data_hash"]' ).first()
-					.val( data.postedDataHash );
+					.val( data.posted_data_hash );
 			}
 		};
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -149,14 +149,14 @@ function wpcf7_rest_create_contact_form( WP_REST_Request $request ) {
 		'title' => $item->title(),
 		'locale' => $item->locale(),
 		'properties' => $item->get_properties(),
-		'configErrors' => array(),
+		'config_errors' => array(),
 	);
 
 	if ( wpcf7_validate_configuration() ) {
 		$config_validator = new WPCF7_ConfigValidator( $item );
 		$config_validator->validate();
 
-		$response['configErrors'] = $config_validator->collect_error_messages();
+		$response['config_errors'] = $config_validator->collect_error_messages();
 
 		if ( 'save' == $context ) {
 			$config_validator->save();
@@ -230,14 +230,14 @@ function wpcf7_rest_update_contact_form( WP_REST_Request $request ) {
 		'title' => $item->title(),
 		'locale' => $item->locale(),
 		'properties' => $item->get_properties(),
-		'configErrors' => array(),
+		'config_errors' => array(),
 	);
 
 	if ( wpcf7_validate_configuration() ) {
 		$config_validator = new WPCF7_ConfigValidator( $item );
 		$config_validator->validate();
 
-		$response['configErrors'] = $config_validator->collect_error_messages();
+		$response['config_errors'] = $config_validator->collect_error_messages();
 
 		if ( 'save' == $context ) {
 			$config_validator->save();
@@ -303,7 +303,7 @@ function wpcf7_rest_create_feedback( WP_REST_Request $request ) {
 		'into' => '#' . wpcf7_sanitize_unit_tag( $unit_tag ),
 		'status' => $result['status'],
 		'message' => $result['message'],
-		'postedDataHash' => $result['posted_data_hash'],
+		'posted_data_hash' => $result['posted_data_hash'],
 	);
 
 	if ( 'validation_failed' == $result['status'] ) {
@@ -318,7 +318,7 @@ function wpcf7_rest_create_feedback( WP_REST_Request $request ) {
 			);
 		}
 
-		$response['invalidFields'] = $invalid_fields;
+		$response['invalid_fields'] = $invalid_fields;
 	}
 
 	$response = apply_filters( 'wpcf7_ajax_json_echo', $response, $result );


### PR DESCRIPTION
See #23

Revert the #83 change. Applied the same rule to posted_data_hash and invalid_fields as well.