### PR TITLE
Make an apply_filters_deprecated() clone

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -389,6 +389,24 @@ function wpcf7_deprecated_function( $function, $version, $replacement ) {
 	}
 }
 
+function wpcf7_apply_filters_deprecated( $tag, $args, $version, $replacement ) {
+	if ( ! has_filter( $tag ) ) {
+		return $args[0];
+	}
+
+	if ( WP_DEBUG and apply_filters( 'deprecated_hook_trigger_error', true ) ) {
+		trigger_error(
+			sprintf(
+				/* translators: 1: WordPress hook name, 2: version number, 3: alternative hook name */
+				__( '%1$s is <strong>deprecated</strong> since Contact Form 7 version %2$s! Use %3$s instead.', 'contact-form-7' ),
+				$tag, $version, $replacement
+			)
+		);
+	}
+
+	return apply_filters_ref_array( $tag, $args );
+}
+
 function wpcf7_log_remote_request( $url, $request, $response ) {
 	$log = sprintf(
 		/* translators: 1: response code, 2: message, 3: body, 4: URL */


### PR DESCRIPTION
The original apply_filters_deprecated() is designed for WordPress core filter hooks, so we need a clone function for Contact Form 7 hooks.

See #88