### PR TITLE
Added i18n to the 404 CF7 output

### DIFF
--- a/includes/contact-form-functions.php
+++ b/includes/contact-form-functions.php
@@ -125,7 +125,10 @@ function wpcf7_contact_form_tag_func( $atts, $content = null, $code = '' ) {
 	}
 
 	if ( ! $contact_form ) {
-		return __( '[contact-form-7 404 "Not Found"]', 'contact-form-7' );
+		return sprintf(
+			'[contact-form-7 404 "%s"]',
+			esc_html(__('Not Found', 'contact-form-7'))
+		);
 	}
 
 	return $contact_form->form_html( $atts );

--- a/includes/contact-form-functions.php
+++ b/includes/contact-form-functions.php
@@ -125,7 +125,7 @@ function wpcf7_contact_form_tag_func( $atts, $content = null, $code = '' ) {
 	}
 
 	if ( ! $contact_form ) {
-		return '[contact-form-7 404 "Not Found"]';
+		return __( '[contact-form-7 404 "Not Found"]', 'contact-form-7' );
 	}
 
 	return $contact_form->form_html( $atts );

--- a/includes/contact-form-functions.php
+++ b/includes/contact-form-functions.php
@@ -127,7 +127,7 @@ function wpcf7_contact_form_tag_func( $atts, $content = null, $code = '' ) {
 	if ( ! $contact_form ) {
 		return sprintf(
 			'[contact-form-7 404 "%s"]',
-			esc_html(__('Not Found', 'contact-form-7'))
+			esc_html( __( 'Not Found', 'contact-form-7' ) )
 		);
 	}
 


### PR DESCRIPTION
Adding i18n to the message that appears when the user adds a contact form ID that doesn't exist.

Here's an example with the output translated to Spanish:
<img src="https://i.imgur.com/I0MRKY2.png">