### PR TITLE
Allow multiple file uploads

### DIFF
--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -347,6 +347,68 @@ class WPCF7_FormTag implements ArrayAccess {
 		return (int) $default;
 	}
 
+	public function get_limit_total_option( $default = MB_IN_BYTES ) {
+		$pattern = '/^limit_total:([1-9][0-9]*)([kKmM]?[bB])?$/';
+
+		$matches = $this->get_first_match_option( $pattern );
+
+		if ( $matches ) {
+			$size = (int) $matches[1];
+
+			if ( ! empty( $matches[2] ) ) {
+				$kbmb = strtolower( $matches[2] );
+
+				if ( 'kb' == $kbmb ) {
+					$size *= KB_IN_BYTES;
+				} elseif ( 'mb' == $kbmb ) {
+					$size *= MB_IN_BYTES;
+				}
+			}
+
+			return $size;
+		}
+
+		return (int) $default;
+	}
+
+	public function get_max_option( $default = 10 ) {
+		$option = $this->get_option( 'max', 'int', true );
+
+		if ( $option ) {
+			return $option;
+		}
+
+		$matches_a = $this->get_all_match_options(
+			'%^(?:[0-9]*x?[0-9]*)?/([0-9]+)$%' );
+
+		foreach ( (array) $matches_a as $matches ) {
+			if ( isset( $matches[1] ) && '' !== $matches[1] ) {
+				return $matches[1];
+			}
+		}
+
+		return $default;
+	}
+
+	public function get_min_option( $default = 0 ) {
+		$option = $this->get_option( 'min', 'int', true );
+
+		if ( $option ) {
+			return $option;
+		}
+
+		$matches_a = $this->get_all_match_options(
+			'%^(?:[0-9]*x?[0-9]*)?/([0-9]+)$%' );
+
+		foreach ( (array) $matches_a as $matches ) {
+			if ( isset( $matches[1] ) && '' !== $matches[1] ) {
+				return $matches[1];
+			}
+		}
+
+		return $default;
+	}
+
 	public function get_first_match_option( $pattern ) {
 		foreach( (array) $this->options as $option ) {
 			if ( preg_match( $pattern, $option, $matches ) ) {

--- a/includes/mail.php
+++ b/includes/mail.php
@@ -158,10 +158,12 @@ class WPCF7_Mail {
 		if ( $submission = WPCF7_Submission::get_instance() ) {
 			$uploaded_files = $submission->uploaded_files();
 
-			foreach ( (array) $uploaded_files as $name => $path ) {
-				if ( false !== strpos( $template, "[${name}]" )
-				and ! empty( $path ) ) {
-					$attachments[] = $path;
+			foreach ( (array) $uploaded_files as $name => $paths ) {
+				foreach ($paths as $path) {
+					if ( false !== strpos( $template, "[${name}]" )
+					and ! empty( $path ) ) {
+						$attachments[] = $path;
+					}
 				}
 			}
 		}

--- a/includes/submission.php
+++ b/includes/submission.php
@@ -515,11 +515,15 @@ class WPCF7_Submission {
 			return false;
 		}
 
-		$this->uploaded_files[$name] = $file_path;
+		$this->uploaded_files[$name][] = $file_path;
 
-		if ( empty( $this->posted_data[$name] ) ) {
-			$this->posted_data[$name] = md5_file( $file_path );
+		if (
+			empty( $this->posted_data[$name] ) ||
+			!is_array($this->posted_data[$name])
+		) {
+			$this->posted_data[$name] = [];
 		}
+		$this->posted_data[$name][] = md5_file( $file_path );
 	}
 
 	public function remove_uploaded_files() {

--- a/modules/file.php
+++ b/modules/file.php
@@ -286,8 +286,7 @@ function wpcf7_tag_generator_file( $contact_form, $args = '' ) {
 	<td>
 		<fieldset>
 		<legend class="screen-reader-text"><?php echo esc_html( __( 'Options', 'contact-form-7' ) ); ?></legend>
-		<label><input type="checkbox" name="multiple" class="option" /> <?php echo esc_html( __( 'Allow multiple selections', 'contact-form-7' ) ); ?></label><br />
-		<label><input type="checkbox" name="include_blank" class="option" /> <?php echo esc_html( __( 'Insert a blank item as the first option', 'contact-form-7' ) ); ?></label>
+		<label><input type="checkbox" name="multiple" class="option" /> <?php echo esc_html( __( 'Allow multiple uploads', 'contact-form-7' ) ); ?></label><br />
 		</fieldset>
 	</td>
 	</tr>

--- a/modules/file.php
+++ b/modules/file.php
@@ -93,8 +93,8 @@ function wpcf7_file_validation_filter( $result, $tag ) {
 	$id = $tag->get_id_option();
 
 	$files = [];
-	if (isset($_FILES[$name])) {
-		if (is_array($_FILES[$name])) {
+	if (isset($_FILES[$name]) && isset($_FILES[$name]['name'])) {
+		if (is_array($_FILES[$name]['name'])) {
 			// multiple files uploaded
 			for( $i=0; $i<count($_FILES[$name]['name']); $i++) {
 				$files[] = array(
@@ -194,11 +194,11 @@ function wpcf7_file_mail_tag( $replaced, $submitted, $html, $mail_tag ) {
 	$uploaded_files = $submission->uploaded_files();
 	$name = $mail_tag->field_name();
 
-	if ( ! empty( $uploaded_files[$name] ) ) {
-		$replaced = wp_basename( $uploaded_files[$name] );
-	}
+	$replaced = array_map(function($path){
+		return basename($path);
+	},$uploaded_files[$name]);
 
-	return $replaced;
+	return implode(', ', $replaced);
 }
 
 


### PR DESCRIPTION
I created this pull request following our discussion here: https://wordpress.org/support/topic/allow-upload-of-multiple-files-with-file-my-files-multiple/

This pull requests introduces the `multiple` option to the `[file]` tag. Use it like this:

```
[file my-files multiple]
[submit]
```

Since one file field can now have multiple files attached to it, I had to make some other structural changes, which other plugin developers might need to be aware of.

1. `$submission->uploaded_files` and `$submission->uploaded_files()` will now contain an array of paths, instead of a single path per name. For example: `['my-file' => ['path-to-file/file1.jpg', 'path-to-file/file2.jpg']]`. Even if there is only one file or if you omit the `multiple` option, it will still return an array with one path.
2. Same thing happens for `$submission->posted_data`. Instead of returning an md5 hash for each file field, it will return an array of md5 hashes for each file field.

Users of the plugin need to be aware of the following if they use `[file my-files multiple]`:

1. in the attachments field they can simply input `[my-files]`, this will attach all files to the email.
2. In the email body, `[my-files]` will be replaced by a comma-separated list of the uploaded file names.

@takayukister If you like this idea and would like to include it in the plugin, please let me know and I will make sure to run some additional tests.