### PR TITLE
fix: mail_tag default value

### DIFF
--- a/includes/special-mail-tags.php
+++ b/includes/special-mail-tags.php
@@ -6,7 +6,7 @@
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_special_mail_tag', 10, 4 );
 
-function wpcf7_special_mail_tag( $output, $name, $html, $mail_tag ) {
+function wpcf7_special_mail_tag( $output, $name, $html, $mail_tag = '' ) {
 	$name = preg_replace( '/^wpcf7\./', '_', $name ); // for back-compat
 
 	$submission = WPCF7_Submission::get_instance();
@@ -63,7 +63,7 @@ function wpcf7_special_mail_tag( $output, $name, $html, $mail_tag ) {
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_post_related_smt', 10, 4 );
 
-function wpcf7_post_related_smt( $output, $name, $html, $mail_tag ) {
+function wpcf7_post_related_smt( $output, $name, $html, $mail_tag = '' ) {
 	if ( '_post_' != substr( $name, 0, 6 ) ) {
 		return $output;
 	}
@@ -112,7 +112,7 @@ function wpcf7_post_related_smt( $output, $name, $html, $mail_tag ) {
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_site_related_smt', 10, 4 );
 
-function wpcf7_site_related_smt( $output, $name, $html, $mail_tag ) {
+function wpcf7_site_related_smt( $output, $name, $html, $mail_tag = '' ) {
 	$filter = $html ? 'display' : 'raw';
 
 	if ( '_site_title' == $name ) {
@@ -136,7 +136,7 @@ function wpcf7_site_related_smt( $output, $name, $html, $mail_tag ) {
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_user_related_smt', 10, 4 );
 
-function wpcf7_user_related_smt( $output, $name, $html, $mail_tag ) {
+function wpcf7_user_related_smt( $output, $name, $html, $mail_tag = '' ) {
 	if ( '_user_' != substr( $name, 0, 6 )
 	or '_user_agent' == $name ) {
 		return $output;

--- a/modules/flamingo.php
+++ b/modules/flamingo.php
@@ -258,7 +258,7 @@ function wpcf7_flamingo_update_channel( $contact_form ) {
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_flamingo_serial_number', 10, 4 );
 
-function wpcf7_flamingo_serial_number( $output, $name, $html, $mail_tag ) {
+function wpcf7_flamingo_serial_number( $output, $name, $html, $mail_tag = '' ) {
 	if ( '_serial_number' != $name ) {
 		return $output;
 	}


### PR DESCRIPTION
Hello!
First of all - your plugin is awesome, I appreciate you are maintaining it!

I maintain plugin, dependent of your plugin. And some users noticed, that around a week - two weeks ago it stopped working.
@manuluyten found, that your plugin from the version 5.2.1 in some functions has more parameters than previously.
Link to the issue: https://github.com/moshenskyDV/CF7-spreadsheets/issues/17#issue-681037141

I investigated it, and found you added a parameter `$mail_tag` to couple of functions in your commit: https://github.com/takayukister/contact-form-7/commit/7a3584b2d17402a6c62dfd384c44604fc4960dd6. It brakes my plugin, and probably a lot of plugins, that dependent of your plugin. I haven't found any usage of new parameter `$mail_tag`, so I don't really know, what is it exactly (boolean, string or number...).
I suggest to add default value to this parameter, to not broke backward compatibility.

Hope you'll check it asap!