### PR TITLE
Prevent the $mail_tag to cause fatal errors

### DIFF
--- a/includes/special-mail-tags.php
+++ b/includes/special-mail-tags.php
@@ -6,7 +6,7 @@
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_special_mail_tag', 10, 4 );
 
-function wpcf7_special_mail_tag( $output, $name, $html, $mail_tag ) {
+function wpcf7_special_mail_tag( $output, $name, $html, $mail_tag = '' ) {
 	$name = preg_replace( '/^wpcf7\./', '_', $name ); // for back-compat
 
 	$submission = WPCF7_Submission::get_instance();
@@ -63,7 +63,7 @@ function wpcf7_special_mail_tag( $output, $name, $html, $mail_tag ) {
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_post_related_smt', 10, 4 );
 
-function wpcf7_post_related_smt( $output, $name, $html, $mail_tag ) {
+function wpcf7_post_related_smt( $output, $name, $html, $mail_tag = '' ) {
 	if ( '_post_' != substr( $name, 0, 6 ) ) {
 		return $output;
 	}
@@ -112,7 +112,7 @@ function wpcf7_post_related_smt( $output, $name, $html, $mail_tag ) {
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_site_related_smt', 10, 4 );
 
-function wpcf7_site_related_smt( $output, $name, $html, $mail_tag ) {
+function wpcf7_site_related_smt( $output, $name, $html, $mail_tag = '' ) {
 	$filter = $html ? 'display' : 'raw';
 
 	if ( '_site_title' == $name ) {
@@ -136,7 +136,7 @@ function wpcf7_site_related_smt( $output, $name, $html, $mail_tag ) {
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_user_related_smt', 10, 4 );
 
-function wpcf7_user_related_smt( $output, $name, $html, $mail_tag ) {
+function wpcf7_user_related_smt( $output, $name, $html, $mail_tag = '' ) {
 	if ( '_user_' != substr( $name, 0, 6 )
 	or '_user_agent' == $name ) {
 		return $output;


### PR DESCRIPTION
Add of default value for the new 4th element to prevent fatal errors on third party plugins that integrate with Contact Form 7.