### PR TITLE
Allow the form title to be accessed in the JS event details

### DIFF
--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -344,6 +344,7 @@ class WPCF7_ContactForm {
 				'role' => 'form',
 				'class' => 'wpcf7',
 				'id' => $this->unit_tag(),
+				'title' => get_the_title( $this->id ),
 				( get_option( 'html_type' ) == 'text/html' ) ? 'lang' : 'xml:lang'
 					=> $lang_tag,
 				'dir' => wpcf7_is_rtl( $this->locale ) ? 'rtl' : 'ltr',

--- a/includes/js/scripts.js
+++ b/includes/js/scripts.js
@@ -169,6 +169,7 @@
 
 		var detail = {
 			id: $form.closest( 'div.wpcf7' ).attr( 'id' ),
+			title: $form.closest( 'div.wpcf7' ).attr( 'title' ),
 			status: 'init',
 			inputs: [],
 			formData: formData


### PR DESCRIPTION
The CF7 event listeners (`wpcf7submit`, `wpcf7invalid`, `wpcf7mailsent`, etc.) provide an incredible amount of data for usability measurement and general analytics insight. Over the years I've been able to improve completion rates considerably and it all starts with these event hooks.

However, in analytics software, the only way to identify the forms is via the ID that CF7 provides via `e.detail.id` (Ex: `wpcf7-f1962-p905-o1`). While this is extremely handy, it does require the analyst to have access to WordPress to look up the form ID, or inspect the source code of various pages to find the right form. Additionally, there is an extra step to combine data if the form exists on multiple pages.

![Screen Shot 2020-08-29 at 1 07 40 PM](https://user-images.githubusercontent.com/6349678/91642354-ac4b5200-e9f8-11ea-83b3-b2553b441c26.png)

Not a huge hurdle, but as a quality of life improvement, I've submitted a pull request to add the form title to the JS event detail object (`e.detail.title`). This way, the descriptive title can be associated with the analytics data if preferred.

Example:
```js
jQuery(document).on('wpcf7mailsent', function(e){
	console.log(e.detail.title); //Title of the successfully submitted form
});
```

Sorry for the long writeup, but I wanted to make sure I clearly described the benefit of this feature. Thanks.

Cross-referencing some of my notes here: https://github.com/chrisblakley/Nebula/issues/1382