### PR TITLE
fix tag generator style

### DIFF
--- a/admin/css/styles-rtl.css
+++ b/admin/css/styles-rtl.css
@@ -12,7 +12,7 @@
 	text-align: right;
 }
 
-.tag-generator-panel .control-box > fieldset legend {
+.tag-generator-panel .control-box > fieldset > legend {
 	border: 1px solid #dfdfdf;
 	border-right: 4px solid #00a0d2;
 }

--- a/admin/css/styles.css
+++ b/admin/css/styles.css
@@ -203,16 +203,16 @@ ul.config-error li {
 
 .tag-generator-panel {
 	position: relative;
-	height: 495px;
-	display: flex;
-	flex-direction: column;
+    height: 495px;
+    display: flex;
+    flex-direction: column;
 }
 
 .tag-generator-panel .control-box {
 	padding: 0;
-	margin: 0;
-	height: 380px;
-	overflow: auto;
+    margin: 0;
+    overflow: auto;
+    flex-grow: 1;
 }
 
 .tag-generator-panel .control-box > fieldset > legend {
@@ -276,15 +276,15 @@ ul.config-error li {
 }
 
 .tag-generator-panel .insert-box {
-	margin: 0;
-	padding: 8px 16px;
-	background-color: #fcfcfc;
-	border-top: 1px solid #dfdfdf;
-	overflow: auto;
+	margin: 0 -15px -15px;
+    padding: 8px 16px;
+    background-color: #fcfcfc;
+    border-top: 1px solid #dfdfdf;
+    overflow: auto;
 }
 
 .tag-generator-panel .insert-box input.tag {
-	width: 480px;
+	width: 510px;
 	float: left;
 	background-color: transparent;
 	box-shadow: none;

--- a/admin/css/styles.css
+++ b/admin/css/styles.css
@@ -202,7 +202,6 @@ ul.config-error li {
 }
 
 .tag-generator-panel {
-	position: relative;
 	height: 495px;
 	display: flex;
 	flex-direction: column;

--- a/admin/css/styles.css
+++ b/admin/css/styles.css
@@ -203,16 +203,16 @@ ul.config-error li {
 
 .tag-generator-panel {
 	position: relative;
-    height: 495px;
-    display: flex;
-    flex-direction: column;
+	height: 495px;
+	display: flex;
+	flex-direction: column;
 }
 
 .tag-generator-panel .control-box {
 	padding: 0;
-    margin: 0;
-    overflow: auto;
-    flex-grow: 1;
+	margin: 0;
+	overflow: auto;
+	flex-grow: 1;
 }
 
 .tag-generator-panel .control-box > fieldset > legend {
@@ -277,10 +277,10 @@ ul.config-error li {
 
 .tag-generator-panel .insert-box {
 	margin: 0 -15px -15px;
-    padding: 8px 16px;
-    background-color: #fcfcfc;
-    border-top: 1px solid #dfdfdf;
-    overflow: auto;
+	padding: 8px 16px;
+	background-color: #fcfcfc;
+	border-top: 1px solid #dfdfdf;
+	overflow: auto;
 }
 
 .tag-generator-panel .insert-box input.tag {

--- a/admin/css/styles.css
+++ b/admin/css/styles.css
@@ -203,9 +203,9 @@ ul.config-error li {
 
 .tag-generator-panel {
 	position: relative;
-    height: 495px;
-    display: flex;
-    flex-direction: column;
+	height: 495px;
+	display: flex;
+	flex-direction: column;
 }
 
 .tag-generator-panel .control-box {
@@ -277,10 +277,10 @@ ul.config-error li {
 
 .tag-generator-panel .insert-box {
 	margin: 0;
-    padding: 8px 16px;
-    background-color: #fcfcfc;
-    border-top: 1px solid #dfdfdf;
-    overflow: auto;
+	padding: 8px 16px;
+	background-color: #fcfcfc;
+	border-top: 1px solid #dfdfdf;
+	overflow: auto;
 }
 
 .tag-generator-panel .insert-box input.tag {

--- a/admin/css/styles.css
+++ b/admin/css/styles.css
@@ -203,7 +203,9 @@ ul.config-error li {
 
 .tag-generator-panel {
 	position: relative;
-	height: 495px;
+    height: 495px;
+    display: flex;
+    flex-direction: column;
 }
 
 .tag-generator-panel .control-box {
@@ -213,14 +215,15 @@ ul.config-error li {
 	overflow: auto;
 }
 
-.tag-generator-panel .control-box > fieldset legend {
+.tag-generator-panel .control-box > fieldset > legend {
 	border: 1px solid #dfdfdf;
 	border-left: 4px solid #00a0d2;
 	background: #f7fcfe;
 	padding: 4px 12px;
 	margin: 4px 0;
 	line-height: 1.4em;
-	width: 95%;
+	width: 100%;
+	box-sizing: border-box;
 }
 
 .tag-generator-panel table {
@@ -273,17 +276,11 @@ ul.config-error li {
 }
 
 .tag-generator-panel .insert-box {
-	position: absolute;
-	left: -15px;
-	right: -15px;
-	bottom: -15px;
-	width: 100%;
-	height: 84px;
 	margin: 0;
-	padding: 8px 16px;
-	background-color: #fcfcfc;
-	border-top: 1px solid #dfdfdf;
-	overflow: auto;
+    padding: 8px 16px;
+    background-color: #fcfcfc;
+    border-top: 1px solid #dfdfdf;
+    overflow: auto;
 }
 
 .tag-generator-panel .insert-box input.tag {
@@ -294,7 +291,7 @@ ul.config-error li {
 }
 
 .tag-generator-panel .insert-box .submitbox {
-	padding: 2px 4px;
+	padding: 0;
 }
 
 .tag-generator-panel .insert-box .submitbox input[type="button"] {


### PR DESCRIPTION
Reduce the amount of scrollbars in the tag generator pop up

Before fix:
![image](https://user-images.githubusercontent.com/1150196/91657835-b175d300-eac4-11ea-9384-13599eabbac2.png)

After fix:
![image](https://user-images.githubusercontent.com/1150196/91658132-dc612680-eac6-11ea-83ff-0723ec047909.png)

