### PR TITLE
add date option filter

### DIFF
--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -203,6 +203,11 @@ class WPCF7_FormTag implements ArrayAccess {
 			return gmdate( 'Y-m-d', strtotime( $format ) );
 		}
 
+		$date = apply_filters( 'wpcf7_form_tag_date_option' , $this->get_option($opt, '', true) );
+		if ( preg_match( '/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $date ) ) {
+			return $date; 
+		}
+
 		return false;
 	}
 

--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -203,7 +203,7 @@ class WPCF7_FormTag implements ArrayAccess {
 			return gmdate( 'Y-m-d', strtotime( $format ) );
 		}
 
-		$date = apply_filters( 'wpcf7_form_tag_date_option' , $this->get_option($opt, '', true) );
+		$date = apply_filters( 'wpcf7_form_tag_date_option', $this->get_option( $opt, '', true ) );
 		if ( preg_match( '/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $date ) ) {
 			return $date; 
 		}

--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -183,6 +183,15 @@ class WPCF7_FormTag implements ArrayAccess {
 	}
 
 	public function get_date_option( $opt ) {
+		$result = apply_filters( 'wpcf7_form_tag_date_option',
+			null,
+			array( $opt => $this->get_option( $opt, '', true ) )
+		);
+
+		if ( $result and preg_match( '/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $result ) ) {
+			return $result;
+		}
+
 		$option = $this->get_option( $opt, 'date', true );
 
 		if ( preg_match( '/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $option ) ) {
@@ -201,11 +210,6 @@ class WPCF7_FormTag implements ArrayAccess {
 			$format = sprintf( '%1$s %2$s %3$s', $today, $number, $unit );
 
 			return gmdate( 'Y-m-d', strtotime( $format ) );
-		}
-
-		$date = apply_filters( 'wpcf7_form_tag_date_option', $this->get_option( $opt, '', true ) );
-		if ( preg_match( '/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $date ) ) {
-			return $date; 
 		}
 
 		return false;


### PR DESCRIPTION
Contact form 7 has `max`, `min` option in date field and  we can use a relative date format (e.g., ‘today+10days’, ‘today-2weeks’) as well in this option.
I want to expand this format from plugin or function.php. 

example

> set `max` option by this year.

```
// in contact form 7
[date date-test max:this-year]
```

``` php
// in funcion.php
function action_wpcf7_form_tag_date_option( $opt ) { 
	$target_opt = 'this-year';
	if ( $opt == $target_opt) {
		$year = date('Y');
		return "$year-12-31";
	}
}; 
add_filter( 'wpcf7_form_tag_date_option', 'action_wpcf7_form_tag_date_option', 10, 1 );
```