### PR TITLE
Feature/checkbox label instead of span

### DIFF
--- a/modules/acceptance.php
+++ b/modules/acceptance.php
@@ -67,12 +67,12 @@ function wpcf7_acceptance_form_tag_handler( $tag ) {
 	if ( $content ) {
 		if ( $tag->has_option( 'label_first' ) ) {
 			$html = sprintf(
-				'<span class="wpcf7-list-item-label">%2$s</span><input %1$s />',
-				$item_atts, $content );
+				'<label for="%3$s" class="wpcf7-list-item-label">%2$s</label><input %1$s />',
+				$item_atts, $content, $item_atts['id']);
 		} else {
 			$html = sprintf(
-				'<input %1$s /><span class="wpcf7-list-item-label">%2$s</span>',
-				$item_atts, $content );
+				'<input %1$s /><label for="%3$s" class="wpcf7-list-item-label">%2$s</label>',
+				$item_atts, $content, $item_atts['id']);
 		}
 
 		$html = sprintf(

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -99,7 +99,9 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 			$label = $value;
 		}
 
+		$item_id=strtolower('wpcf7_'.$tag->basetype.'_'.$tag->name.'_'.$value);
 		$item_atts = array(
+			'id' => $item_id,
 			'type' => $tag->basetype,
 			'name' => $tag->name . ( $multiple ? '[]' : '' ),
 			'value' => $value,
@@ -111,13 +113,13 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 
 		if ( $label_first ) { // put label first, input last
 			$item = sprintf(
-				'<span class="wpcf7-list-item-label">%1$s</span><input %2$s />',
-				esc_html( $label ), $item_atts
+				'<label for="%3$s" class="wpcf7-list-item-label">%1$s</label><input %2$s />',
+				esc_html( $label ), $item_atts, $item_id
 			);
 		} else {
 			$item = sprintf(
-				'<input %2$s /><span class="wpcf7-list-item-label">%1$s</span>',
-				esc_html( $label ), $item_atts
+				'<input %2$s /><label for="%3$s" class="wpcf7-list-item-label">%1$s</label>',
+				esc_html( $label ), $item_atts, $item_id
 			);
 		}
 


### PR DESCRIPTION
Using the <label> tag instead of <span> gives the option to select a value of a checkbox or radio button by clicking the label.
It would even allow for the labels to be styled as buttons.