### PR TITLE
Update config-validator.php

### DIFF
--- a/includes/config-validator.php
+++ b/includes/config-validator.php
@@ -578,7 +578,7 @@ class WPCF7_ConfigValidator {
 				}
 			}
 
-			$max = 25 * MB_IN_BYTES; // 25 MB
+			$max = apply_filters('wpcf7_message_size_limit',25 * MB_IN_BYTES); // Default: 25 MB
 
 			if ( $max < $total_size ) {
 				$this->add_error( sprintf( '%s.attachments', $template ),


### PR DESCRIPTION
Hard message limit is good for most of the installations. But some of the servers accept even 100 megabytes messages. In other cases the sum of all limits in field type inputs will never be reached cause some of the fields show conditionally. That's why it would be good to give user control over this limit. This update will add a new filter allowing devs to change the limit according to their needs with keeping the default limit to 25 megabytes.