### PR TITLE
update deprecated option-key "blacklist_keys"

### DIFF
--- a/modules/disallowed-list.php
+++ b/modules/disallowed-list.php
@@ -49,7 +49,7 @@ function wpcf7_disallowed_list( $spam, $submission ) {
 }
 
 function wpcf7_check_disallowed_list( $target ) {
-	$mod_keys = trim( get_option( 'blacklist_keys' ) );
+	$mod_keys = trim( get_option( 'disallowed_keys' ) );
 
 	if ( '' === $mod_keys ) {
 		return false;


### PR DESCRIPTION
replace "blacklist_keys" with current active "disallowed_keys"
@see https://github.com/WordPress/WordPress/blob/5.5.3/wp-includes/option.php#L42-L59