### PR TITLE
Remove `<p>\s*</p>` later

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -39,8 +39,10 @@ function wpcf7_autop( $pee, $br = 1 ) {
 		$pee .= '<p>' . trim( $tinkle, "\n" ) . "</p>\n";
 	}
 
-	$pee = preg_replace( '|<p>\s*</p>|', '', $pee ); // under certain strange conditions it could create a P of entirely whitespace
 	$pee = preg_replace( '!<p>([^<]+)</(div|address|form|fieldset)>!', "<p>$1</p></$2>", $pee );
+
+	$pee = preg_replace( '|<p>\s*</p>|', '', $pee ); // under certain strange conditions it could create a P of entirely whitespace
+
 	$pee = preg_replace( '!<p>\s*(</?' . $allblocks . '[^>]*>)\s*</p>!', "$1", $pee ); // don't pee all over a tag
 	$pee = preg_replace( "|<p>(<li.+?)</p>|", "$1", $pee ); // problem with nested lists
 	$pee = preg_replace( '|<p><blockquote([^>]*)>|i', "<blockquote$1><p>", $pee );


### PR DESCRIPTION
This fixes https://wordpress.org/support/topic/closing-p-tag/