### PR TITLE
Remove vertical-align property from the spinner icon

### DIFF
--- a/includes/css/styles.css
+++ b/includes/css/styles.css
@@ -82,7 +82,6 @@
 	border-radius: 100%;
 	padding: 0;
 	margin: 0 24px;
-	vertical-align: middle;
 	position: relative;
 }
 


### PR DESCRIPTION
To align based on the baseline.

#281