### PR TITLE
Add color name comment for consistency and clarity

### DIFF
--- a/admin/css/styles.css
+++ b/admin/css/styles.css
@@ -51,7 +51,7 @@ span.shortcode input {
 }
 
 #submitpost input.delete:hover {
-	color: #dc3232;
+	color: #dc3232; /* Red */
 }
 
 #submitpost input.delete:focus {
@@ -64,7 +64,7 @@ span.shortcode input {
 
 .keyboard-interaction {
 	visibility: hidden;
-	color: #23282d;
+	color: #23282d; /* Dark Gray 800 */
 }
 
 div.config-error, span.config-error, ul.config-error {

--- a/includes/css/styles.css
+++ b/includes/css/styles.css
@@ -44,7 +44,7 @@
 }
 
 .wpcf7-not-valid-tip {
-	color: #dc3232;
+	color: #dc3232; /* Red */
 	font-size: 1em;
 	font-weight: normal;
 	display: block;


### PR DESCRIPTION
Follows up on commit that changed red #f00 colors to WordPress red #dc3232. Adds clarity and consistency with comments for Orange, Blue and Green validation colors, as well as existing Gray 800 color comments.