### PR TITLE
Fix #387 add check for wpcf7_load_js on recaptcha scripts

### DIFF
--- a/modules/recaptcha/recaptcha.php
+++ b/modules/recaptcha/recaptcha.php
@@ -23,6 +23,10 @@ function wpcf7_recaptcha_enqueue_scripts() {
 		return;
 	}
 
+	if ( ! wpcf7_load_js() ) {
+		return;
+	}
+
 	wp_enqueue_script( 'google-recaptcha',
 		add_query_arg(
 			array(


### PR DESCRIPTION
As mentioned on the issue itself we need to bailout if we don't need to enqueue recaptcha scripts.

Fixes #387 