### PR TITLE
Apply wp_specialchars_decode() to plain text site title and description

### DIFF
--- a/includes/special-mail-tags.php
+++ b/includes/special-mail-tags.php
@@ -169,11 +169,23 @@ function wpcf7_site_related_smt( $output, $name, $html, $mail_tag = null ) {
 	$filter = $html ? 'display' : 'raw';
 
 	if ( '_site_title' == $name ) {
-		return get_bloginfo( 'name', $filter );
+		$output = get_bloginfo( 'name', $filter );
+
+		if ( ! $html ) {
+			$output = wp_specialchars_decode( $output, ENT_QUOTES );
+		}
+
+		return $output;
 	}
 
 	if ( '_site_description' == $name ) {
-		return get_bloginfo( 'description', $filter );
+		$output = get_bloginfo( 'description', $filter );
+
+		if ( ! $html ) {
+			$output = wp_specialchars_decode( $output, ENT_QUOTES );
+		}
+
+		return $output;
 	}
 
 	if ( '_site_url' == $name ) {


### PR DESCRIPTION
Fixes #398

`wp_notify_postauthor()` does [the same](https://core.trac.wordpress.org/browser/tags/5.4/src/wp-includes/pluggable.php#L1570).