### PR TITLE
Add default value(s) filters

### DIFF
--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -92,12 +92,12 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 
 	$hangover = wpcf7_get_hangover( $tag->name, $multiple ? array() : '' );
 
+	$values = $hangover ? $hangover : $default_choice;
+	$values = apply_filters( 'wpcf7_default_values', $values );
+	$values = apply_filters( 'wpcf7_default_values_checkbox', $values );
+
 	foreach ( $values as $key => $value ) {
-		if ( $hangover ) {
-			$checked = in_array( $value, (array) $hangover, true );
-		} else {
-			$checked = in_array( $value, (array) $default_choice, true );
-		}
+		$checked = in_array( $value, (array) $values, true );
 
 		if ( isset( $labels[$key] ) ) {
 			$label = $labels[$key];

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -93,8 +93,8 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 	$hangover = wpcf7_get_hangover( $tag->name, $multiple ? array() : '' );
 
 	$default_values = $hangover ? $hangover : $default_choice;
-	$default_values = apply_filters( 'wpcf7_default_values', $default_values );
-	$default_values = apply_filters( 'wpcf7_default_values_checkbox', $default_values );
+	$default_values = apply_filters( 'wpcf7_default_values', $default_values, $tag );
+	$default_values = apply_filters( 'wpcf7_default_values_checkbox', $default_values, $tag );
 
 	foreach ( $values as $key => $value ) {
 		$checked = in_array( $value, (array) $default_values, true );

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -92,12 +92,12 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 
 	$hangover = wpcf7_get_hangover( $tag->name, $multiple ? array() : '' );
 
-	$values = $hangover ? $hangover : $default_choice;
-	$values = apply_filters( 'wpcf7_default_values', $values );
-	$values = apply_filters( 'wpcf7_default_values_checkbox', $values );
+	$default_values = $hangover ? $hangover : $default_choice;
+	$default_values = apply_filters( 'wpcf7_default_values', $default_values );
+	$default_values = apply_filters( 'wpcf7_default_values_checkbox', $default_values );
 
 	foreach ( $values as $key => $value ) {
-		$checked = in_array( $value, (array) $values, true );
+		$checked = in_array( $value, (array) $default_values, true );
 
 		if ( isset( $labels[$key] ) ) {
 			$label = $labels[$key];

--- a/modules/date.php
+++ b/modules/date.php
@@ -81,8 +81,8 @@ function wpcf7_date_form_tag_handler( $tag ) {
 
 	$value = wpcf7_get_hangover( $tag->name, $value );
 
-	$value = apply_filters( 'wpcf7_default_value', $value );
-	$value = apply_filters( 'wpcf7_default_value_date', $value );
+	$value = apply_filters( 'wpcf7_default_value', $value, $tag );
+	$value = apply_filters( 'wpcf7_default_value_date', $value, $tag );
 
 	$atts['value'] = $value;
 

--- a/modules/date.php
+++ b/modules/date.php
@@ -81,6 +81,9 @@ function wpcf7_date_form_tag_handler( $tag ) {
 
 	$value = wpcf7_get_hangover( $tag->name, $value );
 
+	$value = apply_filters( 'wpcf7_default_value', $value );
+	$value = apply_filters( 'wpcf7_default_value_date', $value );
+
 	$atts['value'] = $value;
 
 	if ( wpcf7_support_html5() ) {

--- a/modules/hidden.php
+++ b/modules/hidden.php
@@ -25,6 +25,8 @@ function wpcf7_hidden_form_tag_handler( $tag ) {
 
 	$value = (string) reset( $tag->values );
 	$value = $tag->get_default_option( $value );
+	$value = apply_filters( 'wpcf7_default_value', $value );
+	$value = apply_filters( 'wpcf7_default_value_hidden', $value );
 	$atts['value'] = $value;
 
 	$atts['type'] = 'hidden';

--- a/modules/hidden.php
+++ b/modules/hidden.php
@@ -25,8 +25,8 @@ function wpcf7_hidden_form_tag_handler( $tag ) {
 
 	$value = (string) reset( $tag->values );
 	$value = $tag->get_default_option( $value );
-	$value = apply_filters( 'wpcf7_default_value', $value );
-	$value = apply_filters( 'wpcf7_default_value_hidden', $value );
+	$value = apply_filters( 'wpcf7_default_value', $value, $tag );
+	$value = apply_filters( 'wpcf7_default_value_hidden', $value, $tag );
 	$atts['value'] = $value;
 
 	$atts['type'] = 'hidden';

--- a/modules/number.php
+++ b/modules/number.php
@@ -71,6 +71,9 @@ function wpcf7_number_form_tag_handler( $tag ) {
 
 	$value = wpcf7_get_hangover( $tag->name, $value );
 
+	$value = apply_filters( 'wpcf7_default_value', $value );
+	$value = apply_filters( 'wpcf7_default_value_number', $value );
+
 	$atts['value'] = $value;
 
 	if ( wpcf7_support_html5() ) {

--- a/modules/number.php
+++ b/modules/number.php
@@ -71,8 +71,8 @@ function wpcf7_number_form_tag_handler( $tag ) {
 
 	$value = wpcf7_get_hangover( $tag->name, $value );
 
-	$value = apply_filters( 'wpcf7_default_value', $value );
-	$value = apply_filters( 'wpcf7_default_value_number', $value );
+	$value = apply_filters( 'wpcf7_default_value', $value, $tag );
+	$value = apply_filters( 'wpcf7_default_value_number', $value, $tag );
 
 	$atts['value'] = $value;
 

--- a/modules/select.php
+++ b/modules/select.php
@@ -90,8 +90,8 @@ function wpcf7_select_form_tag_handler( $tag ) {
 	$hangover = wpcf7_get_hangover( $tag->name );
 
 	$default_values = $hangover ? $hangover : $default_choice;
-	$default_values = apply_filters( 'wpcf7_default_values', $default_values );
-	$default_values = apply_filters( 'wpcf7_default_values_select', $default_values );
+	$default_values = apply_filters( 'wpcf7_default_values', $default_values, $tag );
+	$default_values = apply_filters( 'wpcf7_default_values_select', $default_values, $tag );
 
 	foreach ( $values as $key => $value ) {
 		$selected = in_array( $value, (array) $default_values, true );

--- a/modules/select.php
+++ b/modules/select.php
@@ -89,12 +89,12 @@ function wpcf7_select_form_tag_handler( $tag ) {
 	$html = '';
 	$hangover = wpcf7_get_hangover( $tag->name );
 
+	$values = $hangover ? $hangover : $default_choice;
+	$values = apply_filters( 'wpcf7_default_values', $values );
+	$values = apply_filters( 'wpcf7_default_values_select', $values );
+
 	foreach ( $values as $key => $value ) {
-		if ( $hangover ) {
-			$selected = in_array( $value, (array) $hangover, true );
-		} else {
-			$selected = in_array( $value, (array) $default_choice, true );
-		}
+		$selected = in_array( $value, (array) $values, true );
 
 		$item_atts = array(
 			'value' => $value,

--- a/modules/select.php
+++ b/modules/select.php
@@ -89,12 +89,12 @@ function wpcf7_select_form_tag_handler( $tag ) {
 	$html = '';
 	$hangover = wpcf7_get_hangover( $tag->name );
 
-	$values = $hangover ? $hangover : $default_choice;
-	$values = apply_filters( 'wpcf7_default_values', $values );
-	$values = apply_filters( 'wpcf7_default_values_select', $values );
+	$default_values = $hangover ? $hangover : $default_choice;
+	$default_values = apply_filters( 'wpcf7_default_values', $default_values );
+	$default_values = apply_filters( 'wpcf7_default_values_select', $default_values );
 
 	foreach ( $values as $key => $value ) {
-		$selected = in_array( $value, (array) $values, true );
+		$selected = in_array( $value, (array) $default_values, true );
 
 		$item_atts = array(
 			'value' => $value,

--- a/modules/text.php
+++ b/modules/text.php
@@ -85,8 +85,8 @@ function wpcf7_text_form_tag_handler( $tag ) {
 
 	$value = wpcf7_get_hangover( $tag->name, $value );
 
-	$value = apply_filters( 'wpcf7_default_value', $value );
-	$value = apply_filters( 'wpcf7_default_value_text', $value );
+	$value = apply_filters( 'wpcf7_default_value', $value, $tag );
+	$value = apply_filters( 'wpcf7_default_value_text', $value, $tag );
 
 	$atts['value'] = $value;
 

--- a/modules/text.php
+++ b/modules/text.php
@@ -85,6 +85,9 @@ function wpcf7_text_form_tag_handler( $tag ) {
 
 	$value = wpcf7_get_hangover( $tag->name, $value );
 
+	$value = apply_filters( 'wpcf7_default_value', $value );
+	$value = apply_filters( 'wpcf7_default_value_text', $value );
+
 	$atts['value'] = $value;
 
 	if ( wpcf7_support_html5() ) {

--- a/modules/textarea.php
+++ b/modules/textarea.php
@@ -76,6 +76,9 @@ function wpcf7_textarea_form_tag_handler( $tag ) {
 
 	$value = wpcf7_get_hangover( $tag->name, $value );
 
+	$value = apply_filters( 'wpcf7_default_value', $value );
+	$value = apply_filters( 'wpcf7_default_value_textarea', $value );
+
 	$atts['name'] = $tag->name;
 
 	$atts = wpcf7_format_atts( $atts );

--- a/modules/textarea.php
+++ b/modules/textarea.php
@@ -76,8 +76,8 @@ function wpcf7_textarea_form_tag_handler( $tag ) {
 
 	$value = wpcf7_get_hangover( $tag->name, $value );
 
-	$value = apply_filters( 'wpcf7_default_value', $value );
-	$value = apply_filters( 'wpcf7_default_value_textarea', $value );
+	$value = apply_filters( 'wpcf7_default_value', $value, $tag );
+	$value = apply_filters( 'wpcf7_default_value_textarea', $value, $tag );
 
 	$atts['name'] = $tag->name;
 


### PR DESCRIPTION
Currently the plugins supports the use of default value(s) [in quite some extend](https://contactform7.com/getting-default-values-from-the-context/). Unfortunately the way it's currently implemented limits the extensibility of this feature by third party users. With this pull request the plugin allows anyone to filter the default value before it's loaded into the form input.

This pull request introduces the following filters to be hooked into:

---

 ```
apply_filters( 'wpcf7_default_value', null|string $value, WPCF7_FormTag $tag )
```
_Filters the default value of the form input._  

**Parameters:**  
- `$value`: ( null | string ) the default value of the input.
- `$tag`: (WPCF7_FormTag) the tag that is being filtered.

**Returns:**  
Either `NULL` or a string value, to use as default value for the input.

---

 ```
apply_filters( 'wpcf7_default_value_{$form_tag}', null|string $value, WPCF7_FormTag $tag )
```
_Filters the default value of the form input for the specified form tag._ 

Where `$form_tag` can be replaced with: "date", "hidden", "number", "text" or "textarea". 

**Parameters:**  
- `$value`: ( null | string ) the default value of the input.
- `$tag`: (WPCF7_FormTag) the tag that is being filtered.

**Returns:**  
Either `NULL` or a string value, to use as default value for the input.

---

 ```
apply_filters( 'wpcf7_default_values', null|string[] $values, WPCF7_FormTag $tag )
```
_Filters the default values of the form input._  

**Parameters:**  
- `$values`: ( null | string[] ) the default values of the input.
- `$tag`: (WPCF7_FormTag) the tag that is being filtered.

**Returns:**  
Either `NULL` or an array of string values, to use as default value(s) for the input.

---

 ```
apply_filters( 'wpcf7_default_values_{$form_tag}', null|string[] $values, WPCF7_FormTag $tag )
```
_Filters the default values of the form input for the specified form tag._  

Where `$form_tag` can be replaced with "checkbox" or "select". 

**Parameters:**  
- `$values`: ( null | string[] ) the default values of the input.
- `$tag`: (WPCF7_FormTag) the tag that is being filtered.

**Returns:**  
Either `NULL` or an array of string values, to use as default value(s) for the input.
