### PR TITLE
Add options, option value and option label filters

### DIFF
--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -86,8 +86,11 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 	$values = $tag->values;
 	$labels = $tag->labels;
 
-	$values = apply_filters( 'wpcf7_options', $values, $tag );
-	$values = apply_filters( 'wpcf7_options_checkbox', $values, $tag );
+	$values = apply_filters( 'wpcf7_form_tag_values', $values, $tag );
+	$values = apply_filters( 'wpcf7_form_tag_values_checkbox', $values, $tag );
+
+	$labels = apply_filters( 'wpcf7_form_tag_labels', $labels, $tag );
+	$labels = apply_filters( 'wpcf7_form_tag_labels_checkbox', $labels, $tag );
 
 	$default_choice = $tag->get_default_option( null, array(
 		'multiple' => $multiple,
@@ -108,9 +111,6 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 			$label = $value;
 		}
 
-		$value = apply_filters( "wpcf7_option_value", $value, $tag, $key);
-		$value = apply_filters( 'wpcf7_option_value_checkbox', $value, $tag, $key);
-
 		$item_atts = array(
 			'type' => $tag->basetype,
 			'name' => $tag->name . ( $multiple ? '[]' : '' ),
@@ -120,9 +120,6 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 		);
 
 		$item_atts = wpcf7_format_atts( $item_atts );
-
-		$label = apply_filters( "wpcf7_option_label", $label, $tag, $key);
-		$label = apply_filters( 'wpcf7_option_label_checkbox', $label, $tag, $key);
 
 		if ( $label_first ) { // put label first, input last
 			$item = sprintf(

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -86,8 +86,8 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 	$values = $tag->values;
 	$labels = $tag->labels;
 
-	$values = apply_filters( 'wpcf7_options', $values);
-	$values = apply_filters( 'wpcf7_options_checkbox', $values);
+	$values = apply_filters( 'wpcf7_options', $values, $tag );
+	$values = apply_filters( 'wpcf7_options_checkbox', $values, $tag );
 
 	$default_choice = $tag->get_default_option( null, array(
 		'multiple' => $multiple,
@@ -108,8 +108,8 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 			$label = $value;
 		}
 
-		$value = apply_filters( "wpcf7_option_value", $value, $key);
-		$value = apply_filters( 'wpcf7_option_value_checkbox', $value, $key);
+		$value = apply_filters( "wpcf7_option_value", $value, $tag, $key);
+		$value = apply_filters( 'wpcf7_option_value_checkbox', $value, $tag, $key);
 
 		$item_atts = array(
 			'type' => $tag->basetype,
@@ -121,8 +121,8 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 
 		$item_atts = wpcf7_format_atts( $item_atts );
 
-		$label = apply_filters( "wpcf7_option_label", $label, $key);
-		$label = apply_filters( 'wpcf7_option_label_checkbox', $label, $key);
+		$label = apply_filters( "wpcf7_option_label", $label, $tag, $key);
+		$label = apply_filters( 'wpcf7_option_label_checkbox', $label, $tag, $key);
 
 		if ( $label_first ) { // put label first, input last
 			$item = sprintf(

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -86,6 +86,9 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 	$values = $tag->values;
 	$labels = $tag->labels;
 
+	$values = apply_filters( 'wpcf7_options', $values);
+	$values = apply_filters( 'wpcf7_options_checkbox', $values);
+
 	$default_choice = $tag->get_default_option( null, array(
 		'multiple' => $multiple,
 	) );
@@ -105,6 +108,9 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 			$label = $value;
 		}
 
+		$value = apply_filters( "wpcf7_option_value", $value, $key);
+		$value = apply_filters( 'wpcf7_option_value_checkbox', $value, $key);
+
 		$item_atts = array(
 			'type' => $tag->basetype,
 			'name' => $tag->name . ( $multiple ? '[]' : '' ),
@@ -114,6 +120,9 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 		);
 
 		$item_atts = wpcf7_format_atts( $item_atts );
+
+		$label = apply_filters( "wpcf7_option_label", $label, $key);
+		$label = apply_filters( 'wpcf7_option_label_checkbox', $label, $key);
 
 		if ( $label_first ) { // put label first, input last
 			$item = sprintf(

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -78,7 +78,7 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 				array_values( $data ),
 				array_slice( $tag->labels, -1 ) );
 		} else {
-			$tag->values = array_merge( $tag->values, array_values( $data ) );
+			$tag->values = array_merge( $tag->values, array_keys( $data ) );
 			$tag->labels = array_merge( $tag->labels, array_values( $data ) );
 		}
 	}

--- a/modules/select.php
+++ b/modules/select.php
@@ -86,8 +86,11 @@ function wpcf7_select_form_tag_handler( $tag ) {
 		$values[0] = '';
 	}
 
-	$values = apply_filters( 'wpcf7_options', $values, $tag);
-	$values = apply_filters( 'wpcf7_options_select', $values, $tag);
+	$values = apply_filters( 'wpcf7_form_tag_values', $values, $tag);
+	$values = apply_filters( 'wpcf7_form_tag_values_select', $values, $tag);
+
+	$labels = apply_filters( 'wpcf7_form_tag_labels', $labels, $tag);
+	$labels = apply_filters( 'wpcf7_form_tag_labels_select', $labels, $tag);
 
 	$html = '';
 	$hangover = wpcf7_get_hangover( $tag->name );
@@ -99,9 +102,6 @@ function wpcf7_select_form_tag_handler( $tag ) {
 			$selected = in_array( $value, (array) $default_choice, true );
 		}
 
-		$value = apply_filters( "wpcf7_option_value", $value, $tag, $key);
-		$value = apply_filters( 'wpcf7_option_value_select', $value, $tag, $key);
-
 		$item_atts = array(
 			'value' => $value,
 			'selected' => $selected ? 'selected' : '',
@@ -110,9 +110,6 @@ function wpcf7_select_form_tag_handler( $tag ) {
 		$item_atts = wpcf7_format_atts( $item_atts );
 
 		$label = isset( $labels[$key] ) ? $labels[$key] : $value;
-
-		$label = apply_filters( "wpcf7_option_label", $label, $tag, $key);
-		$label = apply_filters( 'wpcf7_option_label_select', $label, $tag, $key);
 
 		$html .= sprintf( '<option %1$s>%2$s</option>',
 			$item_atts, esc_html( $label ) );

--- a/modules/select.php
+++ b/modules/select.php
@@ -86,8 +86,8 @@ function wpcf7_select_form_tag_handler( $tag ) {
 		$values[0] = '';
 	}
 
-	$values = apply_filters( 'wpcf7_options', $values);
-	$values = apply_filters( 'wpcf7_options_select', $values);
+	$values = apply_filters( 'wpcf7_options', $values, $tag);
+	$values = apply_filters( 'wpcf7_options_select', $values, $tag);
 
 	$html = '';
 	$hangover = wpcf7_get_hangover( $tag->name );
@@ -99,8 +99,8 @@ function wpcf7_select_form_tag_handler( $tag ) {
 			$selected = in_array( $value, (array) $default_choice, true );
 		}
 
-		$value = apply_filters( "wpcf7_option_value", $value, $key);
-		$value = apply_filters( 'wpcf7_option_value_select', $value, $key);
+		$value = apply_filters( "wpcf7_option_value", $value, $tag, $key);
+		$value = apply_filters( 'wpcf7_option_value_select', $value, $tag, $key);
 
 		$item_atts = array(
 			'value' => $value,
@@ -111,8 +111,8 @@ function wpcf7_select_form_tag_handler( $tag ) {
 
 		$label = isset( $labels[$key] ) ? $labels[$key] : $value;
 
-		$label = apply_filters( "wpcf7_option_label", $label, $key);
-		$label = apply_filters( 'wpcf7_option_label_select', $label, $key);
+		$label = apply_filters( "wpcf7_option_label", $label, $tag, $key);
+		$label = apply_filters( 'wpcf7_option_label_select', $label, $tag, $key);
 
 		$html .= sprintf( '<option %1$s>%2$s</option>',
 			$item_atts, esc_html( $label ) );

--- a/modules/select.php
+++ b/modules/select.php
@@ -86,6 +86,9 @@ function wpcf7_select_form_tag_handler( $tag ) {
 		$values[0] = '';
 	}
 
+	$values = apply_filters( 'wpcf7_options', $values);
+	$values = apply_filters( 'wpcf7_options_select', $values);
+
 	$html = '';
 	$hangover = wpcf7_get_hangover( $tag->name );
 
@@ -96,6 +99,9 @@ function wpcf7_select_form_tag_handler( $tag ) {
 			$selected = in_array( $value, (array) $default_choice, true );
 		}
 
+		$value = apply_filters( "wpcf7_option_value", $value, $key);
+		$value = apply_filters( 'wpcf7_option_value_select', $value, $key);
+
 		$item_atts = array(
 			'value' => $value,
 			'selected' => $selected ? 'selected' : '',
@@ -104,6 +110,9 @@ function wpcf7_select_form_tag_handler( $tag ) {
 		$item_atts = wpcf7_format_atts( $item_atts );
 
 		$label = isset( $labels[$key] ) ? $labels[$key] : $value;
+
+		$label = apply_filters( "wpcf7_option_label", $label, $key);
+		$label = apply_filters( 'wpcf7_option_label_select', $label, $key);
 
 		$html .= sprintf( '<option %1$s>%2$s</option>',
 			$item_atts, esc_html( $label ) );

--- a/modules/select.php
+++ b/modules/select.php
@@ -66,7 +66,7 @@ function wpcf7_select_form_tag_handler( $tag ) {
 	}
 
 	if ( $data = (array) $tag->get_data_option() ) {
-		$tag->values = array_merge( $tag->values, array_values( $data ) );
+		$tag->values = array_merge( $tag->values, array_keys( $data ) );
 		$tag->labels = array_merge( $tag->labels, array_values( $data ) );
 	}
 


### PR DESCRIPTION
Currently there are two possibilities to load in options dynamically, options are the items which can be chosen with a checkbox or select inputs. The first solution, the cleanest way of doing so, is by using the `wpcf7_form_tag_data_option` filter. The only other way to implement this feature is to complete replace the form tag for the desired input. Unfortunately this possibly disables the propagation of updates and requires a lot of boilerplate.

Unfortunately there is an issue with the first solution, what doesn't give you full control of dynamically loading options. The problem is that you can't set a value what is different from the option label. This is because the output of the filter is passed through the `array_values` function for both the values and the labels. In this PR you will find the line changes where the values for the options are no longer passed through `array_values` but `array_keys` instead. Also this PR includes 2 new filters what allow users to filter the labels and values separately.

The filters that this PR includes are:

---

 ```
apply_filters( 'wpcf7_form_tag_values', array $values, WPCF7_FormTag $tag )
```
_Filters the values of the options of the form input._  

**Parameters:**  
- `$values`: ( array ) the input's values.
- `$tag`: (WPCF7_FormTag) the tag that is being filtered.

**Returns:**  
An one-dimensional associative array with the values.

---

 ```
apply_filters( 'wpcf7_form_tag_values_{$form_tag}', array $values, WPCF7_FormTag $tag )
```
_Filters the values of the options of the form input for the specified form tag._  

Where `$form_tag` can be replaced with: "checkbox" or "select". 

**Parameters:**  
- `$values`: ( array ) the input's values.
- `$tag`: (WPCF7_FormTag) the tag that is being filtered.

**Returns:**  
An one-dimensional associative array with the values.

---

 ```
apply_filters( 'wpcf7_form_tag_labels', array $labels, WPCF7_FormTag $tag )
```
_Filters the labels of the options of the form input._  

**Parameters:**  
- `$labels`: ( array ) the input's labels.
- `$tag`: (WPCF7_FormTag) the tag that is being filtered.

**Returns:**  
An one-dimensional associative array with the labels.

---

 ```
apply_filters( 'wpcf7_form_tag_labels_{$form_tag}', array $labels, WPCF7_FormTag $tag )
```
_Filters the labels of the options of the form input for the specified form tag._  

Where `$form_tag` can be replaced with: "checkbox" or "select". 

**Parameters:**  
- `$labels`: ( array ) the input's labels.
- `$tag`: (WPCF7_FormTag) the tag that is being filtered.

**Returns:**  
An one-dimensional associative array with the labels.