### PR TITLE
Update contact-form.php

### DIFF
--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -577,10 +577,10 @@ class WPCF7_ContactForm {
 			esc_html( $primary_response )
 		);
 
-		$validation_errors = sprintf(
+		$validation_errors = $validation_errors ? sprintf(
 			'<ul>%s</ul>',
 			implode( "\n", $validation_errors )
-		);
+		) : '';
 
 		$output = sprintf(
 			'<div class="screen-reader-response">%1$s %2$s</div>',


### PR DESCRIPTION
as proporsed here https://wordpress.org/support/topic/remove-empty-ul-in-screen-reader-response-and-add-it-later/#post-14462647 

will fix WAI-ARIA Issue with empty list (https://www.w3.org/TR/wai-aria-1.1/#mustContain )