### PR TITLE
Revert #536

### DIFF
--- a/modules/stripe/api.php
+++ b/modules/stripe/api.php
@@ -85,11 +85,6 @@ class WPCF7_Stripe_API {
 			unset( $args['receipt_email'] );
 		}
 
-		$args = apply_filters(
-			'wpcf7_stripe_create_payment_intent_params',
-			$args
-		);
-
 		$endpoint = 'https://api.stripe.com/v1/payment_intents';
 
 		$request = array(


### PR DESCRIPTION
There is already the `wpcf7_stripe_payment_intent_parameters` hook.

#465