### PR TITLE
Include WPCF7_UPLOADS_TMP_DIR in the directory validation

### DIFF
--- a/includes/validation-functions.php
+++ b/includes/validation-functions.php
@@ -190,5 +190,10 @@ function wpcf7_is_file_path_in_content_dir( $path ) {
 		return true;
 	}
 
+	if ( defined( 'WPCF7_UPLOADS_TMP_DIR' )
+	and 0 === strpos( realpath( $path ), realpath( WPCF7_UPLOADS_TMP_DIR ) ) ) {
+		return true;
+	}
+
 	return false;
 }


### PR DESCRIPTION
According to my topic on the forum ( https://wordpress.org/support/topic/attachments-blocked-when-uploads-path-uses-symlinks/ ), I propose a fix for this issue.

This fix is very simple and add a test condition when using WPCF7_UPLOADS_TMP_DIR for attachment uploads.