### PR TITLE
fix php 5.6.x compatibility

### DIFF
--- a/admin/includes/welcome-panel.php
+++ b/admin/includes/welcome-panel.php
@@ -6,7 +6,7 @@ abstract class WPCF7_WelcomePanelColumn {
 	abstract protected function title();
 	abstract protected function content();
 
-	public function print() {
+	public function wpcf7_print() {
 		$icon = sprintf(
 			'<span class="dashicons dashicons-%s" aria-hidden="true"></span>',
 			esc_attr( $this->icon() )
@@ -220,7 +220,7 @@ function wpcf7_welcome_panel() {
 <?php
 
 	foreach ( $columns as $column ) {
-		$column->print();
+		$column->wpcf7_print();
 	}
 
 ?>


### PR DESCRIPTION
fixes issue reported on forums https://wordpress.org/support/topic/syntax-error-unexpected-print-t_print-welcome-panel-php/ by prefixing function name.