### PR TITLE
fixed pipes output in emails

### DIFF
--- a/includes/submission.php
+++ b/includes/submission.php
@@ -316,10 +316,10 @@ class WPCF7_Submission {
 			}
 
 			if ( wpcf7_form_tag_supports( $type, 'selectable-values' ) ) {
-				$value = (array) $value;
 
 				if ( $tag->has_option( 'free_text' )
 				and isset( $posted_data[$name . '_free_text'] ) ) {
+					$value = (array) $value;
 					$last_val = array_pop( $value );
 
 					list( $tied_item ) = array_slice(


### PR DESCRIPTION
At the moment, when using tags [_raw_{field name}] and [{field name}], the same value is displayed in the email, pipes don't work. After some research, I found what the problem is.