### PR TITLE
Introduce the wpcf7_pre_construct_contact_form_properties filter hook

### DIFF
--- a/modules/constant-contact/contact-form-properties.php
+++ b/modules/constant-contact/contact-form-properties.php
@@ -1,7 +1,7 @@
 <?php
 
 add_filter(
-	'wpcf7_contact_form_properties',
+	'wpcf7_pre_construct_contact_form_properties',
 	'wpcf7_constant_contact_register_property',
 	10, 2
 );
@@ -26,7 +26,15 @@ add_filter(
 );
 
 function wpcf7_constant_contact_setup_property( $property, $contact_form ) {
-	if ( isset( $property ) ) {
+	if ( ! empty( $property ) ) {
+		$property = wp_parse_args(
+			$property,
+			array(
+				'enable_contact_list' => false,
+				'contact_lists' => array(),
+			)
+		);
+
 		return $property;
 	}
 

--- a/modules/sendinblue/contact-form-properties.php
+++ b/modules/sendinblue/contact-form-properties.php
@@ -1,7 +1,7 @@
 <?php
 
 add_filter(
-	'wpcf7_contact_form_properties',
+	'wpcf7_pre_construct_contact_form_properties',
 	'wpcf7_sendinblue_register_property',
 	10, 2
 );
@@ -9,13 +9,11 @@ add_filter(
 function wpcf7_sendinblue_register_property( $properties, $contact_form ) {
 	$service = WPCF7_Sendinblue::get_instance();
 
-	if ( ! $service->is_active() ) {
-		return $properties;
+	if ( $service->is_active() ) {
+		$properties += array(
+			'sendinblue' => array(),
+		);
 	}
-
-	$properties += array(
-		'sendinblue' => array(),
-	);
 
 	return $properties;
 }


### PR DESCRIPTION
Use `wpcf7_pre_construct_contact_form_properties` to add a property. Use `wpcf7_contact_form_property_{$name}` or `wpcf7_contact_form_properties` to set the default value on the property or modify the value from the database.

#634