### PR TITLE
Don't canonicalize pipe-after

### DIFF
--- a/includes/pipe.php
+++ b/includes/pipe.php
@@ -40,18 +40,12 @@ class WPCF7_Pipes {
 		) );
 
 		foreach ( $this->pipes as $pipe ) {
+			$before_canonical = wpcf7_canonicalize( $pipe->before, array(
+				'strto' => 'as-is',
+			) );
 
-			list( $before, $after ) = array_map(
-				function ( $item ) {
-					return wpcf7_canonicalize( $item, array(
-						'strto' => 'as-is',
-					) );
-				},
-				array( $pipe->before, $pipe->after )
-			);
-
-			if ( $input_canonical === $before ) {
-				return $after;
+			if ( $input_canonical === $before_canonical ) {
+				return $pipe->after;
 			}
 		}
 


### PR DESCRIPTION
This canonicalization of pipe-after has been applied because the value is used for quiz answers of the `[quiz]` form-tag. However, now the quiz module does it in its functions, so doing it in `do_pipe()` is no longer necessary.

#680