### PR TITLE
Refactor wpcf7_acceptable_filetypes()

### DIFF
--- a/modules/file.php
+++ b/modules/file.php
@@ -38,7 +38,8 @@ function wpcf7_file_form_tag_handler( $tag ) {
 	$atts['tabindex'] = $tag->get_option( 'tabindex', 'signed_int', true );
 
 	$atts['accept'] = wpcf7_acceptable_filetypes(
-		$tag->get_option( 'filetypes' ), 'attr' );
+		$tag->get_option( 'filetypes' ), 'attr'
+	);
 
 	if ( $tag->is_required() ) {
 		$atts['aria-required'] = 'true';


### PR DESCRIPTION
Default file types are changed to `audio/*`, `video/*`, and `image/*`.

#737