### PR TITLE
Reset array keys

### DIFF
--- a/includes/form-tags-manager.php
+++ b/includes/form-tags-manager.php
@@ -257,7 +257,7 @@ class WPCF7_FormTagsManager {
 			}
 		);
 
-		return $tags;
+		return array_values( $tags );
 	}
 
 	private function tag_regex() {


### PR DESCRIPTION
`array_filter()` preserves original array keys and that causes error when someone expects `$tags[0]` but `0` key doesn't exist.

Closes #734