### PR TITLE
Exclude text/* or application/*

### DIFF
--- a/includes/file.php
+++ b/includes/file.php
@@ -206,6 +206,12 @@ function wpcf7_acceptable_filetypes( $types = 'default', $format = 'regex' ) {
 			function ( $type ) {
 				if ( false === strpos( $type, '/' ) ) {
 					return sprintf( '.%s', trim( $type, '.' ) );
+				} elseif ( preg_match( '%^([a-z]+)/[*]$%i', $type, $matches ) ) {
+					if ( in_array( $matches[1], array( 'audio', 'video', 'image' ) ) ) {
+						return $type;
+					} else {
+						return '';
+					}
 				} elseif ( wpcf7_convert_mime_to_ext( $type ) ) {
 					return $type;
 				}


### PR DESCRIPTION
The `accept` attribute [does not accept them](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers).

#737