### PR TITLE
Fix. Adding additional parameters on link generating has been fixed.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -277,7 +277,6 @@ function wpcf7_link( $url, $anchor_text, $args = '' ) {
 	);
 
 	$args = wp_parse_args( $args, $defaults );
-	$args = array_intersect_key( $args, $defaults );
 	$atts = wpcf7_format_atts( $args );
 
 	$link = sprintf( '<a href="%1$s"%3$s>%2$s</a>',


### PR DESCRIPTION
Hello, Takayuki Miyoshi,

there is a bug in the link generating function `wpcf7_link()`
Using the function `array_intersect_key()` on the attributes generating flow is unnecessary. The function will cut unique keys from the two arrays.

Example: 
calling something like this
```php
wpcf7_link(
  'https://some.url',
  'Title',
  array('target'=>'_blank')
)
```
so the logic will intersect two arrays: default attributes and parsed attributes 
```php
$default = array(
  'id' => '',
  'class' => '',
);
$parsed_params = array(
  'id' => '',
  'class' => '',
  'target' => '_blank'
);
$output = array_intersect_key($default , $parsed_params);
```

It cut out unique attributes traget=_blank, the output will be like:
```php
$output = array(
  'id' => '',
  'class' => '',
);
```