### PR TITLE
php8.1: Implement ArrayAccess return types

### DIFF
--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -383,13 +383,13 @@ class WPCF7_FormTag implements ArrayAccess {
 		return $result;
 	}
 
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( $offset, $value ): void {
 		if ( property_exists( __CLASS__, $offset ) ) {
 			$this->{$offset} = $value;
 		}
 	}
 
-	public function offsetGet( $offset ) {
+	public function offsetGet( $offset ): mixed {
 		if ( property_exists( __CLASS__, $offset ) ) {
 			return $this->{$offset};
 		}
@@ -397,10 +397,10 @@ class WPCF7_FormTag implements ArrayAccess {
 		return null;
 	}
 
-	public function offsetExists( $offset ) {
+	public function offsetExists( $offset ): bool {
 		return property_exists( __CLASS__, $offset );
 	}
 
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( $offset ): void {
 	}
 }

--- a/includes/validation.php
+++ b/includes/validation.php
@@ -62,7 +62,7 @@ class WPCF7_Validation implements ArrayAccess {
 		return $this->invalid_fields;
 	}
 
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( $offset, $value ): void {
 		if ( isset( $this->container[$offset] ) ) {
 			$this->container[$offset] = $value;
 		}
@@ -75,16 +75,16 @@ class WPCF7_Validation implements ArrayAccess {
 		}
 	}
 
-	public function offsetGet( $offset ) {
+	public function offsetGet( $offset ): mixed  {
 		if ( isset( $this->container[$offset] ) ) {
 			return $this->container[$offset];
 		}
 	}
 
-	public function offsetExists( $offset ) {
+	public function offsetExists( $offset ): bool {
 		return isset( $this->container[$offset] );
 	}
 
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( $offset ): void {
 	}
 }


### PR DESCRIPTION
In PHP 8.1 the plugin triggers some notices, because the return types are missing in the ArrayAccess interface implementations. I have added those return types so it matches the interface.