### PR TITLE
Use #[ReturnTypeWillChange] to suppress PHP 8.1 deprecation notices

### DIFF
--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -513,6 +513,7 @@ class WPCF7_FormTag implements ArrayAccess {
 	 *
 	 * @see https://www.php.net/manual/en/arrayaccess.offsetset.php
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		if ( property_exists( __CLASS__, $offset ) ) {
 			$this->{$offset} = $value;
@@ -525,6 +526,7 @@ class WPCF7_FormTag implements ArrayAccess {
 	 *
 	 * @see https://www.php.net/manual/en/arrayaccess.offsetget.php
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		if ( property_exists( __CLASS__, $offset ) ) {
 			return $this->{$offset};
@@ -539,6 +541,7 @@ class WPCF7_FormTag implements ArrayAccess {
 	 *
 	 * @see https://www.php.net/manual/en/arrayaccess.offsetexists.php
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		return property_exists( __CLASS__, $offset );
 	}
@@ -549,6 +552,7 @@ class WPCF7_FormTag implements ArrayAccess {
 	 *
 	 * @see https://www.php.net/manual/en/arrayaccess.offsetunset.php
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
 	}
 

--- a/includes/validation.php
+++ b/includes/validation.php
@@ -95,6 +95,7 @@ class WPCF7_Validation implements ArrayAccess {
 	 *
 	 * @see https://www.php.net/manual/en/arrayaccess.offsetset.php
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		if ( isset( $this->container[$offset] ) ) {
 			$this->container[$offset] = $value;
@@ -114,6 +115,7 @@ class WPCF7_Validation implements ArrayAccess {
 	 *
 	 * @see https://www.php.net/manual/en/arrayaccess.offsetget.php
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		if ( isset( $this->container[$offset] ) ) {
 			return $this->container[$offset];
@@ -126,6 +128,7 @@ class WPCF7_Validation implements ArrayAccess {
 	 *
 	 * @see https://www.php.net/manual/en/arrayaccess.offsetexists.php
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		return isset( $this->container[$offset] );
 	}
@@ -136,6 +139,7 @@ class WPCF7_Validation implements ArrayAccess {
 	 *
 	 * @see https://www.php.net/manual/en/arrayaccess.offsetunset.php
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
 	}
 


### PR DESCRIPTION
Since PHP 8.1 most non-final internal methods now require overriding methods to declare a compatible return type, otherwise a deprecated notice is emitted during inheritance validation. Compatible return types will be mandatory from PHP 9.0.

Since the plugin still supports PHP 5.6 it's not possible to declare return types (return type declarations have been introduced in PHP 7), this PR uses the #[ReturnTypeWillChange] attribute to suppress the PHP 8.1 deprecation notices to prevent the debug log from being flooded by the notices. Once the plugin drops support for PHP 5.6 the #[ReturnTypeWillChange] attribute can be replaced with proper return type declarations.