### PR TITLE
Don't 'realpath' resolve attachment file path

### DIFF
--- a/includes/validation-functions.php
+++ b/includes/validation-functions.php
@@ -210,12 +210,6 @@ function wpcf7_is_email_in_site_domain( $email ) {
  *              false otherwise.
  */
 function wpcf7_is_file_path_in_content_dir( $path ) {
-	if ( $real_path = realpath( $path ) ) {
-		$path = $real_path;
-	} else {
-		return false;
-	}
-
 	if ( 0 === strpos( $path, realpath( WP_CONTENT_DIR ) ) ) {
 		return true;
 	}


### PR DESCRIPTION
## The problem

The validation function that checks if the file path is in `WP_CONTENT_DIR` puts an absolute path string through `realpath()`. This will resolve symlinks so instead of `/.../wp-content/uploads` we can get something like `/.../static-wp-assets/uploads`. This happens if my WP is in e.g. `/srv/http/current/wp-content`, my uploads are in `/srv/http/static/uploads` and then this uploads is symlinked to `/srv/http/current/wp-content/uploads`.

So `wpcf7_is_file_path_in_content_dir` will never return `true` because:

```php
// $path = '/srv/http/current/wp-content/uploads/wpcf7_uploads/123/file.jpg'
$real_path = realpath($path);
// $real_path = '/srv/http/static/uploads/wpcf7_uploads/123/file.jpg'
// WP_CONTENT_DIR = '/srv/http/current/wp-content'
$wp_cnt = realpath(WP_CONTENT_DIR);
// $wp_cnt = '/srv/http/current/wp-content'
strpos($real_path, $wp_cnt) === 0 // false
```

Because of this failed check the plugin will not send file attachments.

## The solution

Do not put `$path` through `realpath()`.

I have checked all uses of `wpcf7_is_file_path_in_content_dir` and in all instances the path parameter is concatenated with `WP_CONTENT_DIR`. I don't see a reason for use of `realpath()` anywhere in this function, but the proposed change here at least fixes issues with symlinked directories.

Symlinked files and directories are a common occurrence on VPS deployments with strict file permissions and with the widespread use of this plugin this issue should definitely be addressed. Maybe not accroding to this proposal, but somehow. 

Our current solution is to handle this plugin like premium plugins where we maintain a modded copy outside of git and composer configs.