### PR TITLE
Replace @see with @link

### DIFF
--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -3,7 +3,7 @@
 /**
  * A form-tag.
  *
- * @see https://contactform7.com/tag-syntax/#form_tag
+ * @link https://contactform7.com/tag-syntax/#form_tag
  */
 class WPCF7_FormTag implements ArrayAccess {
 
@@ -511,7 +511,7 @@ class WPCF7_FormTag implements ArrayAccess {
 	/**
 	 * Assigns a value to the specified offset.
 	 *
-	 * @see https://www.php.net/manual/en/arrayaccess.offsetset.php
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetset.php
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
@@ -524,7 +524,7 @@ class WPCF7_FormTag implements ArrayAccess {
 	/**
 	 * Returns the value at specified offset.
 	 *
-	 * @see https://www.php.net/manual/en/arrayaccess.offsetget.php
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetget.php
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
@@ -539,7 +539,7 @@ class WPCF7_FormTag implements ArrayAccess {
 	/**
 	 * Returns true if the specified offset exists.
 	 *
-	 * @see https://www.php.net/manual/en/arrayaccess.offsetexists.php
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetexists.php
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
@@ -550,7 +550,7 @@ class WPCF7_FormTag implements ArrayAccess {
 	/**
 	 * Unsets an offset.
 	 *
-	 * @see https://www.php.net/manual/en/arrayaccess.offsetunset.php
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetunset.php
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -462,7 +462,7 @@ function wpcf7_rmdir_p( $dir ) {
 /**
  * Builds a URL-encoded query string.
  *
- * @see https://developer.wordpress.org/reference/functions/_http_build_query/
+ * @link https://developer.wordpress.org/reference/functions/_http_build_query/
  *
  * @param array $args URL query parameters.
  * @param string $key Optional. If specified, used to prefix key name.
@@ -499,7 +499,7 @@ function wpcf7_build_query( $args, $key = '' ) {
 /**
  * Returns the number of code units in a string.
  *
- * @see http://www.w3.org/TR/html5/infrastructure.html#code-unit-length
+ * @link http://www.w3.org/TR/html5/infrastructure.html#code-unit-length
  *
  * @param string $text Input string.
  * @return int|bool The number of code units, or false if

--- a/includes/validation-functions.php
+++ b/includes/validation-functions.php
@@ -7,7 +7,7 @@
  * and may be followed by any number of letters, digits ([0-9]),
  * hyphens ("-"), underscores ("_"), colons (":"), and periods (".").
  *
- * @see http://www.w3.org/TR/html401/types.html#h-6.2
+ * @link http://www.w3.org/TR/html401/types.html#h-6.2
  *
  * @return bool True if it is a valid name, false if not.
  */
@@ -48,7 +48,7 @@ function wpcf7_is_tel( $text ) {
 /**
  * Checks whether the given text is a well-formed number.
  *
- * @see https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)
+ * @link https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)
  */
 function wpcf7_is_number( $text ) {
 	$result = false;
@@ -72,7 +72,7 @@ function wpcf7_is_number( $text ) {
 /**
  * Checks whether the given text is a valid date.
  *
- * @see https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date)
+ * @link https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date)
  */
 function wpcf7_is_date( $text ) {
 	$result = preg_match( '/^([0-9]{4,})-([0-9]{2})-([0-9]{2})$/', $text, $matches );

--- a/includes/validation.php
+++ b/includes/validation.php
@@ -93,7 +93,7 @@ class WPCF7_Validation implements ArrayAccess {
 	/**
 	 * Assigns a value to the specified offset.
 	 *
-	 * @see https://www.php.net/manual/en/arrayaccess.offsetset.php
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetset.php
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
@@ -113,7 +113,7 @@ class WPCF7_Validation implements ArrayAccess {
 	/**
 	 * Returns the value at specified offset.
 	 *
-	 * @see https://www.php.net/manual/en/arrayaccess.offsetget.php
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetget.php
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
@@ -126,7 +126,7 @@ class WPCF7_Validation implements ArrayAccess {
 	/**
 	 * Returns true if the specified offset exists.
 	 *
-	 * @see https://www.php.net/manual/en/arrayaccess.offsetexists.php
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetexists.php
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
@@ -137,7 +137,7 @@ class WPCF7_Validation implements ArrayAccess {
 	/**
 	 * Unsets an offset.
 	 *
-	 * @see https://www.php.net/manual/en/arrayaccess.offsetunset.php
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetunset.php
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {


### PR DESCRIPTION
`@see` is for referring to WP core function/class name.

#525