### PR TITLE
Pass the $submission object to wpcf7_stripe_payment_intent_parameters

### DIFF
--- a/modules/stripe/stripe.php
+++ b/modules/stripe/stripe.php
@@ -163,7 +163,8 @@ function wpcf7_stripe_before_send_mail( $contact_form, &$abort, $submission ) {
 			'amount' => $amount ? absint( $amount ) : null,
 			'currency' => $currency ? strtolower( $currency ) : null,
 			'receipt_email' => $submission->get_posted_data( 'your-email' ),
-		)
+		),
+    $submission
 	);
 
 	$payment_intent = $service->api()->create_payment_intent(


### PR DESCRIPTION
Right now, the `wpcf7_stripe_payment_intent_parameters` filter allows changing the : amount , currency and receipt_email, but, there's no way to access information from the original submission.

This would allow implementation of conditional logic where the amount can be changed if a certain field, has a certain value.

Also created an issue : #900 