### PR TITLE
Fixed PHP Notice

### DIFF
--- a/includes/block-editor/block.json
+++ b/includes/block-editor/block.json
@@ -31,5 +31,5 @@
 			"default": "form"
 		}
 	},
-	"editorScript": "file:./index.js"
+	"editorScript": "./index.js"
 }


### PR DESCRIPTION
Thanks to @dominikkucharski , by https://wordpress.org/support/topic/error-after-last-update-48/
Fixed the following PHP Notice:

`Notice: The register_block_script_handle function was called incorrectly. The resource file for "editorScript" defined in the block definition "contact-form-7/contact-form-selector" is missing. Read Debugging in WordPress for more information.`

File: includes/block-editor/block.json
Line: 34

Before: "editorScript": "file:./index.js"
After fix: "editorScript": "./index.js"