### PR TITLE
Enable async loading of google recaptcha

### DIFF
--- a/modules/recaptcha/index.js
+++ b/modules/recaptcha/index.js
@@ -1,1 +1,62 @@
-document.addEventListener("DOMContentLoaded",(t=>{var e;wpcf7_recaptcha={...null!==(e=wpcf7_recaptcha)&&void 0!==e?e:{}};const c=wpcf7_recaptcha.sitekey,{homepage:n,contactform:a}=wpcf7_recaptcha.actions,o=t=>{const{action:e,func:n,params:a}=t;grecaptcha.execute(c,{action:e}).then((t=>{const c=new CustomEvent("wpcf7grecaptchaexecuted",{detail:{action:e,token:t}});document.dispatchEvent(c)})).then((()=>{"function"==typeof n&&n(...a)})).catch((t=>console.error(t)))};if(grecaptcha.ready((()=>{o({action:n})})),document.addEventListener("change",(t=>{o({action:a})})),"undefined"!=typeof wpcf7&&"function"==typeof wpcf7.submit){const t=wpcf7.submit;wpcf7.submit=function(e){let c=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};o({action:a,func:t,params:[e,c]})}}document.addEventListener("wpcf7grecaptchaexecuted",(t=>{const e=document.querySelectorAll('form.wpcf7-form input[name="_wpcf7_recaptcha_response"]');for(let c=0;c<e.length;c++)e[c].setAttribute("value",t.detail.token)}))}));
+//enable async loading of script handle "google-recaptcha"
+
+//timing check
+const grecaptchaWaitPromise = ms => new Promise(res => setTimeout(res, ms));
+
+//check for defined grecaptcha or wait
+const maybeWaitForGrecaptchaDefined = async () => {
+
+	await grecaptchaWaitPromise(300);
+
+	if(typeof grecaptcha === "undefined"){
+		maybeWaitForGrecaptchaDefined();
+	}else{
+		wpcf7_recaptcha_callback();
+	}
+	
+}
+
+//run
+maybeWaitForGrecaptchaDefined();
+
+//extracted original inline function
+//document.addEventListener("DOMContentLoaded", wpcf7_recaptcha_callback());
+function wpcf7_recaptcha_callback(t) {
+	
+    var e;
+    wpcf7_recaptcha = { ...(null !== (e = wpcf7_recaptcha) && void 0 !== e ? e : {}) };
+    const c = wpcf7_recaptcha.sitekey,
+        { homepage: n, contactform: a } = wpcf7_recaptcha.actions,
+        o = (t) => {
+            const { action: e, func: n, params: a } = t;
+            grecaptcha
+                .execute(c, { action: e })
+                .then((t) => {
+                    const c = new CustomEvent("wpcf7grecaptchaexecuted", { detail: { action: e, token: t } });
+                    document.dispatchEvent(c);
+                })
+                .then(() => {
+                    "function" == typeof n && n(...a);
+                })
+                .catch((t) => console.error(t));
+        };
+    if (
+        (grecaptcha.ready(() => {
+            o({ action: n });
+        }),
+        document.addEventListener("change", (t) => {
+            o({ action: a });
+        }),
+        "undefined" != typeof wpcf7 && "function" == typeof wpcf7.submit)
+    ) {
+        const t = wpcf7.submit;
+        wpcf7.submit = function (e) {
+            let c = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : {};
+            o({ action: a, func: t, params: [e, c] });
+        };
+    }
+    document.addEventListener("wpcf7grecaptchaexecuted", (t) => {
+        const e = document.querySelectorAll('form.wpcf7-form input[name="_wpcf7_recaptcha_response"]');
+        for (let c = 0; c < e.length; c++) e[c].setAttribute("value", t.detail.token);
+    });
+}


### PR DESCRIPTION
Hi, I don't know if this is a very elegant solution to my problem, but I will present it nevertheless. :)

I was trying to load the google-recaptcha script async and and also integrate it into our cookie consent tool (usercentics cmp v2).

To integrate it into the cmp the type has to be set to "text/plain" and additionally the script needs a data attribute ( data-usercentrics='reCaptcha v3' ),  this is done with the filter 'script_loader_tag'.

If the user gives consent to the specific service the cmp will enable all the code and run it. As cf7 attaches itself to DOMContentLoaded it never fired for this scenario. index.js is also set so async and text/plain on load, 

!!! I don't know what happens with the wait timer when grecaptcha never comes online. (which does not happen in my scenario)

I think there is additional work needed to get it nice and clean, but it works for me now. Thank you.