### PR TITLE
Unbreak on PHP versions < 7.3

### DIFF
--- a/includes/contact-form-functions.php
+++ b/includes/contact-form-functions.php
@@ -227,7 +227,7 @@ function wpcf7_contact_form_tag_func( $atts, $content = null, $code = '' ) {
 		return sprintf(
 			'<p class="wpcf7-contact-form-not-found"><strong>%1$s</strong> %2$s</p>',
 			esc_html( __( 'Error:', 'contact-form-7' ) ),
-			esc_html( __( "Contact form not found.", 'contact-form-7' ) ),
+			esc_html( __( "Contact form not found.", 'contact-form-7' ) )
 		);
 	}
 


### PR DESCRIPTION
trailing comma in function calls is supported since PHP 7.3