### PR TITLE
Fix shortcode_atts_wpcf7 filter issue

### DIFF
--- a/includes/contact-form-functions.php
+++ b/includes/contact-form-functions.php
@@ -49,8 +49,9 @@ function wpcf7_get_contact_form_by_title( $title ) {
 		'posts_per_page' => 1,
 	) );
 
-	if ( $contact_forms ) {
-		return wpcf7_contact_form( reset( $contact_forms ) );
+	if ( !empty( $contact_forms ) ) {
+		$contact_form = reset( $contact_forms );
+		return wpcf7_contact_form( $contact_form->id() );
 	}
 }
 


### PR DESCRIPTION
The new method to get the contact form returns the entire contact form rather than just the contact form's ID. This prevented default value defined in the shortcode no longer worked.

The change made returns the contact form ID instead of the contact form object.