### PR TITLE
reCAPTCHA badge positioning

### DIFF
--- a/modules/recaptcha/recaptcha.php
+++ b/modules/recaptcha/recaptcha.php
@@ -44,10 +44,18 @@ function wpcf7_recaptcha_enqueue_scripts() {
 		$url = 'https://www.recaptcha.net/recaptcha/api.js';
 	}
 
+
+	$badge_postition = apply_filters( 'wpcf7_recaptcha_badge_position', 'bottomright' );
+
+	if ( ! in_array( $badge_postition, [ 'bottomright' , 'bottomleft' , 'inline' ] ) ) {
+		$badge_postition = 'bottomright';
+	}
+
 	wp_register_script( 'google-recaptcha',
 		add_query_arg(
 			array(
 				'render' => $service->get_sitekey(),
+				'badge' => $badge_postition,
 			),
 			$url
 		),


### PR DESCRIPTION
I've added a filter which allows the reCAPTCHA badge to be positioned in a different place from the default bottom right.

For example if you would like it to be on the bottom left you can add this filter:

```php
add_filter( 'wpcf7_recaptcha_badge_position',

  function( $badge_position ) {
    $badge_position = 'bottomleft'; // bottom left
 
    return $badge_position;
  },
 
  10, 1
);
```

Google allows the options `bottomright`, `bottomleft` and `inline`, defaulting to `bottomright`.