### PR TITLE
Add '_site_domain' special tag

### DIFF
--- a/includes/special-mail-tags.php
+++ b/includes/special-mail-tags.php
@@ -192,6 +192,14 @@ function wpcf7_site_related_smt( $output, $name, $html, $mail_tag = null ) {
 		return get_bloginfo( 'url', $filter );
 	}
 
+	if ( '_site_domain' == $name ) {
+		$url = get_bloginfo( 'url', $filter );
+		$parse = parse_url( $url );
+		$domain = preg_replace( '/^www\./', '', $parse['host'] );
+
+		return $domain;
+	}
+	
 	if ( '_site_admin_email' == $name ) {
 		return get_bloginfo( 'admin_email', $filter );
 	}


### PR DESCRIPTION
Added a "_site_domain" special tag. 

Usage example for Sender field: 
[_site_title] <wordpress@[_site_domain]>

Using this in "sender" field comes handy when copies of the site is available on multiple subdomains e.g. live, development or testing sites on different subdomains. This way there is no need to update all CF7 forms on each copy/deploy.

For example, if I have a development site on 'dev.example.com' and want to deploy my site to 'example.com' located on a different server, I will not have to change all forms mail settings on each deploy. 

It is extra useful when sites are on different servers. And the domains do not authorize each others servers to send mail via SPF record exposing each others IPs.

Frontend JS validation is not happy with the syntax. I did not dive any deeper in that so far.