### PR TITLE
Conditionally enqueue scripts and styles only if there is a contact form rendered

### DIFF
--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -652,6 +652,14 @@ class WPCF7_ContactForm {
 		$html .= "\n" . '</form>';
 		$html .= "\n" . '</div>';
 
+		if ( wpcf7_load_js() ) {
+			wpcf7_enqueue_scripts();
+		}
+
+		if ( wpcf7_load_css() ) {
+			wpcf7_enqueue_styles();
+		}
+
 		return $html . "\n";
 	}
 

--- a/includes/controller.php
+++ b/includes/controller.php
@@ -29,11 +29,11 @@ function wpcf7_control_init() {
 
 
 /**
- * Registers main scripts and styles.
+ * Registers main scripts.
  */
 add_action(
-	'wp_enqueue_scripts',
-	static function () {
+	'wp_default_scripts',
+	static function ( WP_Scripts $scripts ) {
 		$assets = array();
 		$asset_file = wpcf7_plugin_path( 'includes/js/index.asset.php' );
 
@@ -46,7 +46,7 @@ add_action(
 			'version' => WPCF7_VERSION,
 		) );
 
-		wp_register_script(
+		$scripts->add(
 			'contact-form-7',
 			wpcf7_plugin_url( 'includes/js/index.js' ),
 			array_merge(
@@ -54,22 +54,28 @@ add_action(
 				array( 'swv' )
 			),
 			$assets['version'],
-			true
+			1 // in_footer
 		);
 
-		wp_register_script(
+		$scripts->add(
 			'contact-form-7-html5-fallback',
 			wpcf7_plugin_url( 'includes/js/html5-fallback.js' ),
 			array( 'jquery-ui-datepicker' ),
 			WPCF7_VERSION,
-			true
+			1 // in_footer
 		);
+	},
+	10, 1
+);
 
-		if ( wpcf7_load_js() ) {
-			wpcf7_enqueue_scripts();
-		}
 
-		wp_register_style(
+/**
+ * Registers main styles.
+ */
+add_action(
+	'wp_default_styles',
+	static function ( WP_Styles $styles ) {
+		$styles->add(
 			'contact-form-7',
 			wpcf7_plugin_url( 'includes/css/styles.css' ),
 			array(),
@@ -77,7 +83,7 @@ add_action(
 			'all'
 		);
 
-		wp_register_style(
+		$styles->add(
 			'contact-form-7-rtl',
 			wpcf7_plugin_url( 'includes/css/styles-rtl.css' ),
 			array( 'contact-form-7' ),
@@ -85,7 +91,7 @@ add_action(
 			'all'
 		);
 
-		wp_register_style(
+		$styles->add(
 			'jquery-ui-smoothness',
 			wpcf7_plugin_url(
 				'includes/js/jquery-ui/themes/smoothness/jquery-ui.min.css'
@@ -94,12 +100,8 @@ add_action(
 			'1.12.1',
 			'screen'
 		);
-
-		if ( wpcf7_load_css() ) {
-			wpcf7_enqueue_styles();
-		}
 	},
-	10, 0
+	10, 1
 );
 
 
@@ -107,6 +109,10 @@ add_action(
  * Enqueues scripts.
  */
 function wpcf7_enqueue_scripts() {
+	if ( did_action( 'wpcf7_enqueue_scripts' ) ) {
+		return;
+	}
+
 	wp_enqueue_script( 'contact-form-7' );
 
 	$wpcf7 = array(
@@ -138,6 +144,10 @@ function wpcf7_script_is() {
  * Enqueues styles.
  */
 function wpcf7_enqueue_styles() {
+	if ( did_action( 'wpcf7_enqueue_styles' ) ) {
+		return;
+	}
+
 	wp_enqueue_style( 'contact-form-7' );
 
 	if ( wpcf7_is_rtl() ) {

--- a/includes/controller.php
+++ b/includes/controller.php
@@ -167,7 +167,7 @@ function wpcf7_style_is() {
 
 
 add_action(
-	'wp_enqueue_scripts',
+	'wpcf7_enqueue_scripts',
 	'wpcf7_html5_fallback',
 	20, 0
 );

--- a/includes/swv/script-loader.php
+++ b/includes/swv/script-loader.php
@@ -1,8 +1,8 @@
 <?php
 
 add_action(
-	'wp_enqueue_scripts',
-	static function () {
+	'wp_default_scripts',
+	static function ( WP_Scripts $scripts ) {
 		$assets = array();
 		$asset_file = wpcf7_plugin_path( 'includes/swv/js/index.asset.php' );
 
@@ -15,12 +15,12 @@ add_action(
 			'version' => WPCF7_VERSION,
 		) );
 
-		wp_register_script( 'swv',
+		$scripts->add( 'swv',
 			wpcf7_plugin_url( 'includes/swv/js/index.js' ),
 			$assets['dependencies'],
 			$assets['version'],
-			true
+			1 // in_footer
 		);
 	},
-	10, 0
+	10, 1
 );

--- a/modules/recaptcha/recaptcha.php
+++ b/modules/recaptcha/recaptcha.php
@@ -23,13 +23,22 @@ function wpcf7_recaptcha_register_service() {
 
 
 add_action(
-	'wpcf7_enqueue_scripts',
+	'wp_enqueue_scripts',
 	'wpcf7_recaptcha_enqueue_scripts',
 	20, 0
 );
 
 /**
  * Enqueues frontend scripts for reCAPTCHA.
+ *
+ * Note that this runs at the `wp_enqueue_scripts` action instead of `wpcf7_enqueue_scripts` because the reCAPTCHA
+ * v3 documentation states that the script should be included on every page of a site, even on pages that don't use it:
+ *
+ * > reCAPTCHA works best when it has the most context about interactions with your site, which comes from seeing both
+ * > legitimate and abusive behavior. For this reason, we recommend including reCAPTCHA verification on forms or actions
+ * > as well as in the background of pages for analytics.
+ *
+ * @link https://developers.google.com/recaptcha/docs/v3#placement_on_your_website
  */
 function wpcf7_recaptcha_enqueue_scripts() {
 	$service = WPCF7_RECAPTCHA::get_instance();

--- a/modules/recaptcha/recaptcha.php
+++ b/modules/recaptcha/recaptcha.php
@@ -23,7 +23,7 @@ function wpcf7_recaptcha_register_service() {
 
 
 add_action(
-	'wp_enqueue_scripts',
+	'wpcf7_enqueue_scripts',
 	'wpcf7_recaptcha_enqueue_scripts',
 	20, 0
 );


### PR DESCRIPTION
This improves frontend performance (the LCP metric) of the plugin by eliminating stylesheets and scripts from being enqueued on the frontend if there are no contact forms present. When all integrations are enabled (Stripe and ~reCAPTCHA~) this reduces TTFB-LCP by almost half on vanilla WordPress homepages (running Twenty Twenty-Three) without contact forms.

Update regarding reCAPTCHA: As pointed out by @PhilMakower in https://github.com/rocklobster-in/contact-form-7/issues/1278#issuecomment-1691339382, reCAPTCHA actually works best when it is included on every page, even those that don't use contact forms. So when the reCAPTCHA integration is enabled, its script will continue to be enqueued on all pages. Once this PR is merged, I'll open another one to implement [async loading of the reCAPTCHA scripts](https://developers.google.com/recaptcha/docs/loading#loading_recaptcha_asynchronously) ([`add/async-recaptcha` branch](https://github.com/westonruter/contact-form-7/compare/fix/unconditional-enqueues...westonruter:contact-form-7:add/async-recaptcha))

Fixes #1278.