### PR TITLE
Allow file paths in WordPress temp directory

### DIFF
--- a/includes/validation-functions.php
+++ b/includes/validation-functions.php
@@ -268,5 +268,9 @@ function wpcf7_is_file_path_in_content_dir( $path ) {
 		return true;
 	}
 
+	if ( 0 === strpos( $path, realpath( get_temp_dir() ) ) ) {
+		return true;
+	}
+
 	return false;
 }


### PR DESCRIPTION
The CF7 `wpcf7_upload_dir` filter might be set to the WordPress `get_temp_dir()` function, which may return a path outside of `WP_CONTENT_DIR` (e.g., `/tmp/`):

https://developer.wordpress.org/reference/functions/get_temp_dir/

This commit fixes an issue where files uploaded to CF7 would be saved to the WordPress temp directory, but would not be emailed in the form submission email.

Fixes https://github.com/rocklobster-in/contact-form-7/issues/1282