### PR TITLE
Fixed file path validation error on Windows

### DIFF
--- a/includes/validation-functions.php
+++ b/includes/validation-functions.php
@@ -260,21 +260,21 @@ function wpcf7_is_file_path_in_content_dir( $path ) {
 	}
 
 	if (
-		str_starts_with( $path, trailingslashit( realpath( WP_CONTENT_DIR ) ) )
+		str_starts_with( $path, untrailingslashit( realpath( WP_CONTENT_DIR ) ) )
 	) {
 		return true;
 	}
 
 	if (
 		defined( 'UPLOADS' ) and
-		str_starts_with( $path, trailingslashit( realpath( ABSPATH . UPLOADS ) ) )
+		str_starts_with( $path, untrailingslashit( realpath( ABSPATH . UPLOADS ) ) )
 	) {
 		return true;
 	}
 
 	if (
 		defined( 'WP_TEMP_DIR' ) and
-		str_starts_with( $path, trailingslashit( realpath( WP_TEMP_DIR ) ) )
+		str_starts_with( $path, untrailingslashit( realpath( WP_TEMP_DIR ) ) )
 	) {
 		return true;
 	}


### PR DESCRIPTION
Recent changes in the `validation-functions.php` file result in the error `Failed to attach a file. %s is not in the allowed directory.` on Windows systems when CF7 validates the path of uploaded files.

**Environment:**

- Windows 10 Pro
- Apache 2.4
- PHP version 7.4
- WordPress version 6.3
- Contact Form 7 version 5.8.1

The path separators in the `$path` variable and in cross-checked paths in the `wpcf7_is_file_path_in_content_dir()` function are inconsistent.

**Example:**

````
Value of $path:
C:\projects\wordpress\wp-content\uploads\wpcf7_uploads\1353256270\test-6.pdf

Value of trailingslashit( realpath( WP_CONTENT_DIR ) ):
C:\projects\wordpress\wp-content/
````

Variable `$path` has a backslash after `wp-content\` and the other value has a slash `wp-content/`.

I would suggest to use `untrailingslashit()` instead of `trailingslashit()` to solve this issue.
An alternative would be to normalize all paths with `wp_normalize_path()` before validating them.
