### PR TITLE
Improve readability of string interpolation in filters, to prevent deprecated messages on PHP.

### DIFF
--- a/includes/config-validator/mail.php
+++ b/includes/config-validator/mail.php
@@ -396,7 +396,7 @@ trait WPCF7_ConfigValidator_Mail {
 			foreach ( $tags as $tag ) {
 				$name = $tag->name;
 
-				if ( ! str_contains( $content, "[{$name}]" ) ) {
+				if ( ! str_contains( $content, "[$name]" ) ) {
 					continue;
 				}
 

--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -310,7 +310,7 @@ class WPCF7_ContactForm {
 
 		foreach ( $properties as $name => $val ) {
 			$properties[$name] = apply_filters(
-				"wpcf7_contact_form_property_{$name}",
+				"wpcf7_contact_form_property_$name",
 				$val, $this
 			);
 		}

--- a/includes/mail.php
+++ b/includes/mail.php
@@ -309,7 +309,7 @@ class WPCF7_Mail {
 			$uploaded_files = $submission->uploaded_files();
 
 			foreach ( (array) $uploaded_files as $name => $paths ) {
-				if ( false !== strpos( $template, "[{$name}]" ) ) {
+				if ( false !== strpos( $template, "[$name]" ) ) {
 					$attachments = array_merge( $attachments, (array) $paths );
 				}
 			}
@@ -528,7 +528,7 @@ class WPCF7_MailTaggedText {
 			$type = $form_tag->type;
 
 			$replaced = apply_filters(
-				"wpcf7_mail_tag_replaced_{$type}", $replaced,
+				"wpcf7_mail_tag_replaced_$type", $replaced,
 				$submitted, $html, $mail_tag
 			);
 		}

--- a/includes/submission.php
+++ b/includes/submission.php
@@ -443,7 +443,7 @@ class WPCF7_Submission {
 				}
 			}
 
-			$value = apply_filters( "wpcf7_posted_data_{$type}", $value,
+			$value = apply_filters( "wpcf7_posted_data_$type", $value,
 				$value_orig, $tag
 			);
 
@@ -632,7 +632,7 @@ class WPCF7_Submission {
 
 		foreach ( $tags as $tag ) {
 			$type = $tag->type;
-			$result = apply_filters( "wpcf7_validate_{$type}", $result, $tag );
+			$result = apply_filters( "wpcf7_validate_$type", $result, $tag );
 		}
 
 		$result = apply_filters( 'wpcf7_validate', $result, $tags );
@@ -909,7 +909,7 @@ class WPCF7_Submission {
 			}
 
 			$result = apply_filters(
-				"wpcf7_validate_{$tag->type}",
+				"wpcf7_validate_$tag->type",
 				$result, $tag,
 				array(
 					'uploaded_files' => $new_files,


### PR DESCRIPTION
Refactored the string interpolation used in various filter applications across multiple PHP files. Specifically, removed unnecessary curly braces around variable names within strings. This change improves the readability and clarity of the code, but does not affect the actual functionality or performance.