### PR TITLE
Fix incorrect return type for `wpcf7_swv_create_rule()` mentioned in PhpDoc

### DIFF
--- a/includes/swv/swv.php
+++ b/includes/swv/swv.php
@@ -66,7 +66,7 @@ function wpcf7_swv_load_rules() {
  *
  * @param string $rule_name Rule name.
  * @param string|array $properties Optional. Rule properties.
- * @return Rule|null The rule object, or null if it failed.
+ * @return \Contactable\SWV\Rule|null The rule object, or null if it failed.
  */
 function wpcf7_swv_create_rule( $rule_name, $properties = '' ) {
 	$rules = wpcf7_swv_available_rules();


### PR DESCRIPTION
Function `wpcf7_swv_create_rule` mentions `Rule` class without a namespace. This is causing IDE to show type warnings when adding rules to the `WPCF7_SWV_Schema` object:

```php
class Example
{
    public function add_rules( \WPCF7_SWV_Schema $schema ): void
    {
        $schema->add_rule(
            wpcf7_swv_create_rule( 'required', [
                'field' => 'example',
                'error' => wpcf7_get_message( 'invalid_required' )
            ] )
        );
    }
}
```

Here is a screenshot of this warning from PhpStorm:

![Screenshot of the warning message in PhpStorm](https://github.com/rocklobster-in/contact-form-7/assets/15185230/45c46f55-4d45-4904-a1a5-435131ee93f9)

After adding the namespace to the returned type, warning goes away.