### PR TITLE
Get url from post if no referrer is present

### DIFF
--- a/includes/submission.php
+++ b/includes/submission.php
@@ -537,12 +537,12 @@ class WPCF7_Submission {
 			$referer = trim( $_SERVER['HTTP_REFERER'] ?? '' );
 
 			if ( ! $referer ) {
-                $post_id = (int) $_POST['postId'] ?? 0;
+				$post_id = (int) $_POST['postId'] ?? 0;
 
-                if ( $post_id ) {
-                    $referer = get_permalink($post_id);
-                }
-            }
+				if ( $post_id ) {
+					$referer = get_permalink($post_id);
+				}
+			}
 
 			if ( $referer
 			and 0 === strpos( $referer, $home_url ) ) {

--- a/includes/submission.php
+++ b/includes/submission.php
@@ -536,6 +536,14 @@ class WPCF7_Submission {
 		if ( self::is_restful() ) {
 			$referer = trim( $_SERVER['HTTP_REFERER'] ?? '' );
 
+			if ( ! $referer ) {
+                $post_id = (int) $_POST['postId'] ?? 0;
+
+                if ( $post_id ) {
+                    $referer = get_permalink($post_id);
+                }
+            }
+
 			if ( $referer
 			and 0 === strpos( $referer, $home_url ) ) {
 				return sanitize_url( $referer );


### PR DESCRIPTION
When you run your website on a server with a referrer policy set to no-referrer special mail tag `_url` will return the ajax url, which I believe will never be useful for an admin. I've added a fallback for this scenario to use the post url instead.

Issue mentioned by other users:
https://wordpress.org/support/topic/special-mail-tag-_url-returns-wrong-url/