### PR TITLE
Fix: Fixed layout collapse in Safari browser

### DIFF
--- a/admin/edit-contact-form.php
+++ b/admin/edit-contact-form.php
@@ -81,7 +81,7 @@ if ( $post ) :
 <input type="hidden" id="active-tab" name="active-tab" value="<?php echo esc_attr( $_GET['active-tab'] ?? '' ); ?>" />
 
 <div id="poststuff">
-<div id="post-body" class="metabox-holder columns-2">
+<div id="post-body" class="metabox-holder columns-2 wp-clearfix">
 <div id="post-body-content">
 <div id="titlediv">
 <div id="titlewrap">


### PR DESCRIPTION
## Description
Fixed a layout issue in the admin panel caused by float: left properties.

## Solution
- Added WordPress standard wp-clearfix class to the parent element
- Resolved unintended layout collapse caused by float properties

## Verification
- Confirmed that the layout displays correctly in the admin panel
- Verified no negative impact on other elements