### PR TITLE
Add support for multiple file uploads from one file dialog.

### DIFF
--- a/admin/includes/tag-generator.php
+++ b/admin/includes/tag-generator.php
@@ -189,6 +189,7 @@ class WPCF7_TagGeneratorGenerator {
 	private function field_type( $options = '' ) {
 		$options = wp_parse_args( $options, array(
 			'with_required' => false,
+			'support_multiple' => false,
 			'select_options' => array(),
 		) );
 
@@ -215,6 +216,14 @@ class WPCF7_TagGeneratorGenerator {
 	<label>
 		<input type="checkbox" data-tag-part="type-suffix" value="*" />
 		<?php echo esc_html( __( "This is a required field.", 'contact-form-7' ) ); ?>
+	</label>
+	<?php } ?>
+
+	<?php if ( $options['support_multiple'] ) { ?>
+	<br />
+	<label>
+		<input type="checkbox" data-tag-part="option" data-tag-option="multiple" />
+		<?php echo esc_html( __( "Support multiple file uploads.", 'contact-form-7' ) ); ?>
 	</label>
 	<?php } ?>
 </fieldset>

--- a/modules/file.php
+++ b/modules/file.php
@@ -37,6 +37,7 @@ function wpcf7_file_form_tag_handler( $tag ) {
 	$atts['id'] = $tag->get_id_option();
 	$atts['capture'] = $tag->get_option( 'capture', '(user|environment)', true );
 	$atts['tabindex'] = $tag->get_option( 'tabindex', 'signed_int', true );
+	$atts['multiple'] = $tag->has_option( 'multiple' );
 
 	$atts['accept'] = wpcf7_acceptable_filetypes(
 		$tag->get_option( 'filetypes' ), 'attr'
@@ -57,6 +58,10 @@ function wpcf7_file_form_tag_handler( $tag ) {
 
 	$atts['type'] = 'file';
 	$atts['name'] = $tag->name;
+
+	if ( $atts['multiple'] ) {
+		$atts['name'] .= '[]';
+	}
 
 	$html = sprintf(
 		'<span class="wpcf7-form-control-wrap" data-name="%1$s"><input %2$s />%3$s</span>',
@@ -180,6 +185,7 @@ function wpcf7_tag_generator_file( $contact_form, $options ) {
 	<?php
 		$tgg->print( 'field_type', array(
 			'with_required' => true,
+			'support_multiple' => true,
 			'select_options' => array(
 				'file' => $field_types['file']['display_name'],
 			),


### PR DESCRIPTION
I have a client who wants multiple upload support for his form using Contact Form 7, so I coded it so that it works on his site.  Hopefully will work elsewhere also.  This adds a checkbox to the 'file' tab builder for 'Support multiple file uploads' and alters the generated HTML to produce the correct HTML5 for generated uploads with a PHP back-end.  Everything else seemed to already support multiple file uploads from a single &lt;input&gt; box, so this was all that was necessary.