### PR TITLE
Add a Blueprint for WP.org Live Preview

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,0 +1,16 @@
+{
+	"landingPage": "/wp-admin/admin.php?page=wpcf7",
+	"plugins": [
+		"contact-form-7"
+	],
+	"preferredVersions": {
+		"php": "latest",
+		"wp": "latest"
+	},
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}

--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,5 +1,8 @@
 {
 	"landingPage": "/wp-admin/admin.php?page=wpcf7",
+	"features": {
+		"networking": true
+	},
 	"plugins": [
 		"contact-form-7"
 	],


### PR DESCRIPTION
Hi there, this PR proposes to add a Blueprint file so that Contact Form 7 can have a Live Preview button in the WP.org plugin repo. The Live Preview will load your plugin in the WordPress Playground web app using the provided Blueprint.

According to [the WP.org docs](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/#enabling-plugin-previews):

> There are two things required for a plugin preview button to appear to all users:
> 1. A valid blueprint.json file must be provided in a blueprints sub-directory of the plugin’s assets folder.
> 2. The plugin preview must be set to “public” from the plugin’s Advanced view by a committer.

Once those conditions are met, a Live Preview button should appear next to the Download button in the WordPress.org plugin repo, like:

![image](https://github.com/user-attachments/assets/3e26da92-1759-4eb3-9f82-86091d57e80e)

Try <a href="https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9hZG1pbi5waHA/cGFnZT13cGNmNyIsInBsdWdpbnMiOlsiY29udGFjdC1mb3JtLTciXSwiZmVhdHVyZXMiOnsibmV0d29ya2luZyI6dHJ1ZX0sInByZWZlcnJlZFZlcnNpb25zIjp7InBocCI6ImxhdGVzdCIsIndwIjoibGF0ZXN0In0sInN0ZXBzIjpbeyJzdGVwIjoibG9naW4iLCJ1c2VybmFtZSI6ImFkbWluIn1dfQ==" target="_blank">this link</a> for an example of the preview. Note: This link's hash component is just the Base64-encoded JSON of the Blueprint, and you can decode in your browser's dev tools console with `JSON.parse(atob(<hash-value>))`.

Would this be useful to you?