### PR TITLE
Resolve implicit nullable deprecation warning php 8.4

### DIFF
--- a/includes/pipe.php
+++ b/includes/pipe.php
@@ -36,7 +36,7 @@ class WPCF7_Pipes {
 
 	private $pipes = array();
 
-	public function __construct( array $texts = null ) {
+	public function __construct( ?array $texts = null ) {
 		foreach ( (array) $texts as $text ) {
 			$this->add_pipe( $text );
 		}


### PR DESCRIPTION
Solves PHP 8.4 warning

```
Deprecated: WPCF7_Pipes::__construct(): Implicitly marking parameter $texts as nullable is deprecated, the explicit nullable type must be used instead in /Users/..../contact-form-7/includes/pipe.php on line 39
```