### PR TITLE
Prevent null value in `str_starts_with()` to avoid PHP 8.1+ deprecation

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -327,7 +327,7 @@ class WPCF7_REST_Controller {
 	}
 
 	public function create_feedback( WP_REST_Request $request ) {
-		$content_type = $request->get_header( 'Content-Type' );
+		$content_type = $request->get_header( 'Content-Type' ) ?? '';
 
 		if ( ! str_starts_with( $content_type, 'multipart/form-data' ) ) {
 			return new WP_Error( 'wpcf7_unsupported_media_type',


### PR DESCRIPTION
**Description**
- This PR fixes a deprecation warning in PHP 8.1+ caused by passing null to str_starts_with(). The issue occurs when the Content-Type header is missing, returning null instead of a string.

**Changes**
- Ensured $content_type is always a string using ?? '' (null coalescing operator).
- Prevents potential errors in future PHP versions.

**Impact**
- Fixes deprecated warnings in PHP 8.1 and 8.2.
- Improves compatibility and stability of the Contact Form 7 request handler.