### PR TITLE
Fix wp_admin_notice argument type

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -569,14 +569,14 @@ function wpcf7_admin_updated_message( $page, $action, $object ) {
 	}
 
 	if ( ! empty( $message ) ) {
-		wp_admin_notice( esc_html( $message ), 'type=success' );
+		wp_admin_notice( esc_html( $message ), array( 'type' => 'success' ) );
 	}
 
 	if ( 'failed' === $_REQUEST['message'] ) {
 		$message =
 			__( "There was an error saving the contact form.", 'contact-form-7' );
 
-		wp_admin_notice( esc_html( $message ), 'type=error' );
+		wp_admin_notice( esc_html( $message ), array( 'type' => 'error' ) );
 	}
 
 	if ( 'validated' === $_REQUEST['message'] ) {
@@ -594,11 +594,11 @@ function wpcf7_admin_updated_message( $page, $action, $object ) {
 				number_format_i18n( $count_invalid )
 			);
 
-			wp_admin_notice( esc_html( $message ), 'type=warning' );
+			wp_admin_notice( esc_html( $message ), array( 'type' => 'warning' ) );
 		} else {
 			$message = __( "Configuration validation completed. No invalid contact form was found.", 'contact-form-7' );
 
-			wp_admin_notice( esc_html( $message ), 'type=success' );
+			wp_admin_notice( esc_html( $message ), array( 'type' => 'success' ) );
 		}
 	}
 }
@@ -640,7 +640,7 @@ function wpcf7_old_wp_version_error( $page, $action, $object ) {
 			admin_url( 'update-core.php' )
 		);
 
-		wp_admin_notice( $message, 'type=warning' );
+		wp_admin_notice( $message, array( 'type' => 'warning' ) );
 	}
 }
 
@@ -657,7 +657,7 @@ function wpcf7_not_allowed_to_edit( $page, $action, $object ) {
 	if ( ! current_user_can( 'wpcf7_edit_contact_form', $contact_form->id() ) ) {
 		$message = __( "You are not allowed to edit this contact form.", 'contact-form-7' );
 
-		wp_admin_notice( esc_html( $message ), 'type=warning' );
+		wp_admin_notice( esc_html( $message ), array( 'type' => 'warning' ) );
 	}
 }
 
@@ -668,7 +668,7 @@ function wpcf7_outdated_php_warning( $page, $action, $object ) {
 	if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
 		$message = __( "The next major release of Contact Form 7 will discontinue support for outdated PHP versions. If you don't upgrade PHP, you will not be able to upgrade the plugin.", 'contact-form-7' );
 
-		wp_admin_notice( esc_html( $message ), 'type=warning' );
+		wp_admin_notice( esc_html( $message ), array( 'type' => 'warning' ) );
 	}
 }
 
@@ -688,6 +688,6 @@ function wpcf7_ctct_deprecated_warning( $page, $action, $object ) {
 			array( 'http', 'https' )
 		);
 
-		wp_admin_notice( $message, 'type=warning' );
+		wp_admin_notice( $message, array( 'type' => 'warning' ) );
 	}
 }

--- a/admin/includes/config-validator.php
+++ b/admin/includes/config-validator.php
@@ -53,7 +53,7 @@ function wpcf7_admin_warnings_bulk_cv( $page, $action, $object ) {
 			esc_html( $message ),
 			$link
 		),
-		'type=warning'
+		array( 'type' => 'warning' )
 	);
 }
 

--- a/includes/file.php
+++ b/includes/file.php
@@ -416,6 +416,6 @@ function wpcf7_file_display_warning_message( $page, $action, $object ) {
 			$uploads_dir
 		);
 
-		wp_admin_notice( esc_html( $message ), 'type=warning' );
+		wp_admin_notice( esc_html( $message ), array( 'type' => 'warning' ) );
 	}
 }

--- a/modules/constant-contact/service.php
+++ b/modules/constant-contact/service.php
@@ -343,7 +343,7 @@ class WPCF7_ConstantContact extends WPCF7_Service_OAuth2 {
 			case 'success':
 				wp_admin_notice(
 					esc_html( __( "Connection established.", 'contact-form-7' ) ),
-					'type=success'
+					array( 'type' => 'success' )
 				);
 
 				break;
@@ -354,14 +354,14 @@ class WPCF7_ConstantContact extends WPCF7_Service_OAuth2 {
 						esc_html( __( "Error", 'contact-form-7' ) ),
 						esc_html( __( "Failed to establish connection. Please double-check your configuration.", 'contact-form-7' ) )
 					),
-					'type=error'
+					array( 'type' => 'error' )
 				);
 
 				break;
 			case 'updated':
 				wp_admin_notice(
 					esc_html( __( "Configuration updated.", 'contact-form-7' ) ),
-					'type=success'
+					array( 'type' => 'success' )
 				);
 
 				break;

--- a/modules/really-simple-captcha.php
+++ b/modules/really-simple-captcha.php
@@ -277,7 +277,7 @@ function wpcf7_captcha_display_warning_message( $page, $action, $object ) {
 			$uploads_dir
 		);
 
-		wp_admin_notice( esc_html( $message ), 'type=warning' );
+		wp_admin_notice( esc_html( $message ), array( 'type' => 'warning' ) );
 	}
 
 	if (
@@ -286,7 +286,7 @@ function wpcf7_captcha_display_warning_message( $page, $action, $object ) {
 	) {
 		$message = __( "This contact form contains CAPTCHA fields, but the necessary libraries (GD and FreeType) are not available on your server.", 'contact-form-7' );
 
-		wp_admin_notice( esc_html( $message ), 'type=warning' );
+		wp_admin_notice( esc_html( $message ), array( 'type' => 'warning' ) );
 	}
 }
 

--- a/modules/recaptcha/recaptcha.php
+++ b/modules/recaptcha/recaptcha.php
@@ -268,5 +268,5 @@ function wpcf7_admin_warnings_recaptcha_v2_v3( $page, $action, $object ) {
 		)
 	);
 
-	wp_admin_notice( $message, 'type=warning' );
+	wp_admin_notice( $message, array( 'type' => 'warning' ) );
 }

--- a/modules/recaptcha/service.php
+++ b/modules/recaptcha/service.php
@@ -261,14 +261,14 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 					esc_html( __( "Error", 'contact-form-7' ) ),
 					esc_html( __( "Invalid key values.", 'contact-form-7' ) )
 				),
-				'type=error'
+				array( 'type' => 'error' )
 			);
 		}
 
 		if ( 'success' === $message ) {
 			wp_admin_notice(
 				esc_html( __( "Settings saved.", 'contact-form-7' ) ),
-				'type=success'
+				array( 'type' => 'success' )
 			);
 		}
 	}

--- a/modules/sendinblue/service.php
+++ b/modules/sendinblue/service.php
@@ -124,7 +124,7 @@ class WPCF7_Sendinblue extends WPCF7_Service {
 					esc_html( __( "Error", 'contact-form-7' ) ),
 					esc_html( __( "You have not been authenticated. Make sure the provided API key is correct.", 'contact-form-7' ) )
 				),
-				'type=error'
+				array( 'type' => 'error' )
 			);
 		}
 
@@ -135,14 +135,14 @@ class WPCF7_Sendinblue extends WPCF7_Service {
 					esc_html( __( "Error", 'contact-form-7' ) ),
 					esc_html( __( "Invalid key values.", 'contact-form-7' ) )
 				),
-				'type=error'
+				array( 'type' => 'error' )
 			);
 		}
 
 		if ( 'success' === $message ) {
 			wp_admin_notice(
 				esc_html( __( "Settings saved.", 'contact-form-7' ) ),
-				'type=success'
+				array( 'type' => 'success' )
 			);
 		}
 	}

--- a/modules/stripe/service.php
+++ b/modules/stripe/service.php
@@ -142,14 +142,14 @@ class WPCF7_Stripe extends WPCF7_Service {
 					esc_html( __( "Error", 'contact-form-7' ) ),
 					esc_html( __( "Invalid key values.", 'contact-form-7' ) )
 				),
-				'type=error'
+				array( 'type' => 'error' )
 			);
 		}
 
 		if ( 'success' === $message ) {
 			wp_admin_notice(
 				esc_html( __( "Settings saved.", 'contact-form-7' ) ),
-				'type=success'
+				array( 'type' => 'success' )
 			);
 		}
 	}


### PR DESCRIPTION
`wp_admin_notice()` expects `$args` to be of type `array` (see [function reference](https://developer.wordpress.org/reference/functions/wp_admin_notice/)).