### PR TITLE
Remove useless cast

### DIFF
--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -94,7 +94,7 @@ class WPCF7_ContactForm {
 
 		$objs = array();
 
-		foreach ( (array) $posts as $post ) {
+		foreach ( $posts as $post ) {
 			$objs[] = new self( $post );
 		}
 

--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -177,7 +177,7 @@ class WPCF7_FormTag implements ArrayAccess {
 
 		$matches_a = $this->get_all_match_options( '%^([0-9]*)/[0-9]*$%' );
 
-		foreach ( (array) $matches_a as $matches ) {
+		foreach ( $matches_a as $matches ) {
 			if ( isset( $matches[1] ) and '' !== $matches[1] ) {
 				return $matches[1];
 			}
@@ -204,7 +204,7 @@ class WPCF7_FormTag implements ArrayAccess {
 			'%^(?:[0-9]*x?[0-9]*)?/([0-9]+)$%'
 		);
 
-		foreach ( (array) $matches_a as $matches ) {
+		foreach ( $matches_a as $matches ) {
 			if ( isset( $matches[1] ) and '' !== $matches[1] ) {
 				return $matches[1];
 			}
@@ -248,7 +248,7 @@ class WPCF7_FormTag implements ArrayAccess {
 			'%^([0-9]*)x([0-9]*)(?:/[0-9]+)?$%'
 		);
 
-		foreach ( (array) $matches_a as $matches ) {
+		foreach ( $matches_a as $matches ) {
 			if ( isset( $matches[1] ) and '' !== $matches[1] ) {
 				return $matches[1];
 			}
@@ -275,7 +275,7 @@ class WPCF7_FormTag implements ArrayAccess {
 			'%^([0-9]*)x([0-9]*)(?:/[0-9]+)?$%'
 		);
 
-		foreach ( (array) $matches_a as $matches ) {
+		foreach ( $matches_a as $matches ) {
 			if ( isset( $matches[2] ) and '' !== $matches[2] ) {
 				return $matches[2];
 			}

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -309,7 +309,7 @@ function wpcf7_antiscript_file_name( $filename ) {
 	$filename = array_shift( $parts );
 	$extension = array_pop( $parts );
 
-	foreach ( (array) $parts as $part ) {
+	foreach ( $parts as $part ) {
 		if ( preg_match( $script_pattern, $part ) ) {
 			$filename .= '.' . $part . '_';
 		} else {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -157,7 +157,7 @@ function wpcf7_flat_join( $input, $options = '' ) {
 	$input = wpcf7_array_flatten( $input );
 	$output = array();
 
-	foreach ( (array) $input as $value ) {
+	foreach ( $input as $value ) {
 		if ( is_scalar( $value ) ) {
 			$output[] = trim( (string) $value );
 		}


### PR DESCRIPTION
Removes some useless casts.

- includes/contact-form.php: `$posts = $q->query( $args );` with `WP_Query::query( $args )` always returning an array.
- includes/form-tag.php: `$matches_a = $this->get_all_match_options( $pattern );` with `$this->get_all_match_options( $pattern )` always returning an array.
- includes/formatting.php: `$parts = explode( '.', $filename );` is always an array and remains so after `array_shift()` and `array_pop()`.
- includes/functions.php: `$input = wpcf7_array_flatten( $input );` with `wpcf7_array_flatten( $input );` always returning an array.