### PR TITLE
Remove parentheses around the path of include and require_once

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -127,9 +127,7 @@ function wpcf7_admin_enqueue_scripts( $hook_suffix ) {
 		);
 	}
 
-	$assets = include(
-		wpcf7_plugin_path( 'admin/includes/js/index.asset.php' )
-	);
+	$assets = include wpcf7_plugin_path( 'admin/includes/js/index.asset.php' );
 
 	$assets = wp_parse_args( $assets, array(
 		'dependencies' => array(),

--- a/admin/includes/class-contact-forms-list-table.php
+++ b/admin/includes/class-contact-forms-list-table.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
-	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
 class WPCF7_Contact_Form_List_Table extends WP_List_Table {

--- a/includes/controller.php
+++ b/includes/controller.php
@@ -34,9 +34,7 @@ function wpcf7_control_init() {
 add_action(
 	'wp_enqueue_scripts',
 	static function () {
-		$assets = include(
-			wpcf7_plugin_path( 'includes/js/index.asset.php' )
-		);
+		$assets = include wpcf7_plugin_path( 'includes/js/index.asset.php' );
 
 		$assets = wp_parse_args( $assets, array(
 			'dependencies' => array(),

--- a/includes/l10n.php
+++ b/includes/l10n.php
@@ -17,7 +17,7 @@ function wpcf7_l10n() {
 		return $l10n;
 	}
 
-	require_once( ABSPATH . 'wp-admin/includes/translation-install.php' );
+	require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 
 	$api = translations_api( 'plugins', array(
 		'slug' => 'contact-form-7',

--- a/includes/swv/script-loader.php
+++ b/includes/swv/script-loader.php
@@ -7,7 +7,7 @@ add_action(
 		$asset_file = wpcf7_plugin_path( 'includes/swv/js/index.asset.php' );
 
 		if ( file_exists( $asset_file ) ) {
-			$assets = include( $asset_file );
+			$assets = include $asset_file;
 		}
 
 		$assets = wp_parse_args( $assets, array(

--- a/modules/recaptcha/recaptcha.php
+++ b/modules/recaptcha/recaptcha.php
@@ -56,9 +56,7 @@ function wpcf7_recaptcha_enqueue_scripts() {
 		array( 'in_footer' => true )
 	);
 
-	$assets = include(
-		wpcf7_plugin_path( 'modules/recaptcha/index.asset.php' )
-	);
+	$assets = include wpcf7_plugin_path( 'modules/recaptcha/index.asset.php' );
 
 	$assets = wp_parse_args( $assets, array(
 		'dependencies' => array(),

--- a/modules/stripe/stripe.php
+++ b/modules/stripe/stripe.php
@@ -55,9 +55,7 @@ function wpcf7_stripe_enqueue_scripts() {
 		null
 	);
 
-	$assets = include(
-		wpcf7_plugin_path( 'modules/stripe/index.asset.php' )
-	);
+	$assets = include wpcf7_plugin_path( 'modules/stripe/index.asset.php' );
 
 	$assets = wp_parse_args( $assets, array(
 		'dependencies' => array(),


### PR DESCRIPTION
`include[_once]` and `require[_once]` are language constructs, they do not need parentheses around the path, so those shouldn’t be used (see [WP Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#writing-include-require-statements)).

#23