### PR TITLE
Remove comma after last array item in single-line array

### DIFF
--- a/includes/html-formatter.php
+++ b/includes/html-formatter.php
@@ -484,16 +484,16 @@ class WPCF7_HTMLFormatter {
 		// Descendant can contain ancestors.
 		static $nesting_families = array(
 			array(
-				'ancestors' => array( 'dl', ),
-				'descendants' => array( 'dd', 'dt', ),
+				'ancestors' => array( 'dl' ),
+				'descendants' => array( 'dd', 'dt' ),
 			),
 			array(
-				'ancestors' => array( 'ol', 'ul', 'menu', ),
-				'descendants' => array( 'li', ),
+				'ancestors' => array( 'ol', 'ul', 'menu' ),
+				'descendants' => array( 'li' ),
 			),
 			array(
-				'ancestors' => array( 'table', ),
-				'descendants' => array( 'td', 'th', 'tr', 'thead', 'tbody', 'tfoot', ),
+				'ancestors' => array( 'table' ),
+				'descendants' => array( 'td', 'th', 'tr', 'thead', 'tbody', 'tfoot' ),
 			),
 		);
 


### PR DESCRIPTION
Removes the comma after the last array item in single-line arrays to maintain consistency with the rest of the codebase.

#23