### PR TITLE
Use parenthesis when instantiating a new object instance

### DIFF
--- a/admin/includes/tag-generator.php
+++ b/admin/includes/tag-generator.php
@@ -17,7 +17,7 @@ class WPCF7_TagGenerator {
 	 */
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance = new self();
 		}
 
 		return self::$instance;

--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -119,7 +119,7 @@ class WPCF7_ContactForm {
 		}
 
 		$callback = static function ( $options ) {
-			$contact_form = new self;
+			$contact_form = new self();
 			$contact_form->title = $options['title'];
 			$contact_form->locale = $options['locale'];
 
@@ -1313,7 +1313,7 @@ class WPCF7_ContactForm {
 	 * @return WPCF7_ContactForm New contact form object.
 	 */
 	public function copy() {
-		$new = new self;
+		$new = new self();
 		$new->title = $this->title . '_copy';
 		$new->locale = $this->locale;
 		$new->properties = $this->properties;

--- a/includes/form-tags-manager.php
+++ b/includes/form-tags-manager.php
@@ -75,7 +75,7 @@ class WPCF7_FormTagsManager {
 	 */
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance = new self();
 		}
 
 		return self::$instance;

--- a/includes/integration.php
+++ b/includes/integration.php
@@ -36,7 +36,7 @@ class WPCF7_Integration {
 	 */
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance = new self();
 			self::$instance->categories = self::get_builtin_categories();
 		}
 

--- a/includes/pipe.php
+++ b/includes/pipe.php
@@ -127,7 +127,7 @@ trait WPCF7_PipesHolder {
 			return $this->pipes[$field_name];
 		}
 
-		$result = new WPCF7_Pipes;
+		$result = new WPCF7_Pipes();
 
 		$tags = $this->scan_form_tags( array(
 			'name' => $field_name,

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -3,7 +3,7 @@
 add_action(
 	'rest_api_init',
 	static function () {
-		$controller = new WPCF7_REST_Controller;
+		$controller = new WPCF7_REST_Controller();
 		$controller->register_routes();
 	},
 	10, 0

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -41,7 +41,7 @@ class WPCF7_ShortcodeManager {
 			'WPCF7_FormTagsManager::get_instance' );
 
 		self::$form_tags_manager = WPCF7_FormTagsManager::get_instance();
-		return new self;
+		return new self();
 	}
 
 	public function get_scanned_tags() {

--- a/modules/akismet/service.php
+++ b/modules/akismet/service.php
@@ -11,7 +11,7 @@ class WPCF7_Akismet extends WPCF7_Service {
 
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance = new self();
 		}
 
 		return self::$instance;

--- a/modules/constant-contact/constant-contact.php
+++ b/modules/constant-contact/constant-contact.php
@@ -91,7 +91,7 @@ function wpcf7_constant_contact_submit( $contact_form, $result ) {
 		return;
 	}
 
-	$request_builder = new $request_builder_class_name;
+	$request_builder = new $request_builder_class_name();
 	$request_builder->build( $submission );
 
 	if ( ! $request_builder->is_valid() ) {

--- a/modules/constant-contact/service.php
+++ b/modules/constant-contact/service.php
@@ -19,7 +19,7 @@ class WPCF7_ConstantContact extends WPCF7_Service_OAuth2 {
 
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance = new self();
 		}
 
 		return self::$instance;

--- a/modules/recaptcha/service.php
+++ b/modules/recaptcha/service.php
@@ -13,7 +13,7 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance = new self();
 		}
 
 		return self::$instance;

--- a/modules/sendinblue/service.php
+++ b/modules/sendinblue/service.php
@@ -12,7 +12,7 @@ class WPCF7_Sendinblue extends WPCF7_Service {
 
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance = new self();
 		}
 
 		return self::$instance;

--- a/modules/stripe/service.php
+++ b/modules/stripe/service.php
@@ -12,7 +12,7 @@ class WPCF7_Stripe extends WPCF7_Service {
 
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance = new self();
 		}
 
 		return self::$instance;


### PR DESCRIPTION
#23 - See [WP Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#object-instantiation)