### PR TITLE
Fix file comment format

### DIFF
--- a/includes/special-mail-tags.php
+++ b/includes/special-mail-tags.php
@@ -1,8 +1,8 @@
 <?php
 /**
-** Special Mail Tags
-** https://contactform7.com/special-mail-tags/
-**/
+ * Special Mail Tags
+ * https://contactform7.com/special-mail-tags/
+ */
 
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_special_mail_tag', 10, 4 );
 

--- a/modules/acceptance.php
+++ b/modules/acceptance.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [acceptance]
-**/
+ * A base module for [acceptance]
+ */
 
 /* form_tag handler */
 

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [checkbox], [checkbox*], and [radio]
-**/
+ * A base module for [checkbox], [checkbox*], and [radio]
+ */
 
 /* form_tag handler */
 

--- a/modules/count.php
+++ b/modules/count.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [count], Twitter-like character count
-**/
+ * A base module for [count], Twitter-like character count
+ */
 
 /* form_tag handler */
 

--- a/modules/date.php
+++ b/modules/date.php
@@ -1,8 +1,8 @@
 <?php
 /**
-** A base module for the following types of tags:
-** 	[date] and [date*]		# Date
-**/
+ * A base module for the following types of tags:
+ *      [date] and [date*]              # Date
+ */
 
 /* form_tag handler */
 

--- a/modules/file.php
+++ b/modules/file.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [file] and [file*]
-**/
+ * A base module for [file] and [file*]
+ */
 
 /* form_tag handler */
 

--- a/modules/flamingo.php
+++ b/modules/flamingo.php
@@ -1,8 +1,8 @@
 <?php
 /**
-** Module for Flamingo plugin.
-** http://wordpress.org/extend/plugins/flamingo/
-**/
+ * Module for Flamingo plugin.
+ * http://wordpress.org/extend/plugins/flamingo/
+ */
 
 add_action( 'wpcf7_submit', 'wpcf7_flamingo_submit', 10, 2 );
 

--- a/modules/listo.php
+++ b/modules/listo.php
@@ -1,8 +1,8 @@
 <?php
 /**
-** Retrieve list data from the Listo plugin.
-** Listo http://wordpress.org/plugins/listo/
-**/
+ * Retrieve list data from the Listo plugin.
+ * Listo http://wordpress.org/plugins/listo/
+ */
 
 add_filter( 'wpcf7_form_tag_data_option', 'wpcf7_listo', 10, 3 );
 

--- a/modules/number.php
+++ b/modules/number.php
@@ -1,9 +1,9 @@
 <?php
 /**
-** A base module for the following types of tags:
-** 	[number] and [number*]		# Number
-** 	[range] and [range*]		# Range
-**/
+ * A base module for the following types of tags:
+ *      [number] and [number*]          # Number
+ *      [range] and [range*]            # Range
+ */
 
 /* form_tag handler */
 

--- a/modules/quiz.php
+++ b/modules/quiz.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [quiz]
-**/
+ * A base module for [quiz]
+ */
 
 /* form_tag handler */
 

--- a/modules/really-simple-captcha.php
+++ b/modules/really-simple-captcha.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [captchac] and [captchar]
-**/
+ * A base module for [captchac] and [captchar]
+ */
 
 /* form_tag handler */
 

--- a/modules/response.php
+++ b/modules/response.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [response]
-**/
+ * A base module for [response]
+ */
 
 /* form_tag handler */
 

--- a/modules/select.php
+++ b/modules/select.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [select] and [select*]
-**/
+ * A base module for [select] and [select*]
+ */
 
 /* form_tag handler */
 

--- a/modules/submit.php
+++ b/modules/submit.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [submit]
-**/
+ * A base module for [submit]
+ */
 
 /* form_tag handler */
 

--- a/modules/text.php
+++ b/modules/text.php
@@ -1,11 +1,11 @@
 <?php
 /**
-** A base module for the following types of tags:
-** 	[text] and [text*]		# Single-line text
-** 	[email] and [email*]	# Email address
-** 	[url] and [url*]		# URL
-** 	[tel] and [tel*]		# Telephone number
-**/
+ * A base module for the following types of tags:
+ *      [text] and [text*]              # Single-line text
+ *      [email] and [email*]            # Email address
+ *      [url] and [url*]                # URL
+ *      [tel] and [tel*]                # Telephone number
+ */
 
 /* form_tag handler */
 

--- a/modules/textarea.php
+++ b/modules/textarea.php
@@ -1,7 +1,7 @@
 <?php
 /**
-** A base module for [textarea] and [textarea*]
-**/
+ * A base module for [textarea] and [textarea*]
+ */
 
 /* form_tag handler */
 


### PR DESCRIPTION
Uses a single asterisk except for the opener and uses spaces for alignment.

#23