### PR TITLE
Use array keys and values when merging data options

### DIFF
--- a/modules/select.php
+++ b/modules/select.php
@@ -70,7 +70,7 @@ function wpcf7_select_form_tag_handler( $tag ) {
 	}
 
 	if ( $data = (array) $tag->get_data_option() ) {
-		$tag->values = array_merge( $tag->values, array_values( $data ) );
+		$tag->values = array_merge( $tag->values, array_keys( $data ) );
 		$tag->labels = array_merge( $tag->labels, array_values( $data ) );
 	}
 


### PR DESCRIPTION
This change modifies the way Contact Form 7 merges data options, so that it correctly uses array keys for values and array values for labels. Previously, value => label pipes were not being parsed correctly, causing <option> elements to have the same values and labels when using 'wpcf7_form_tag_data_option' hook.