### PR TITLE
Remove WAI-ARIA role name from the accessible name

### DIFF
--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -603,6 +603,10 @@ class WPCF7_ContactForm {
 		);
 
 		$title_attr = apply_filters( 'wpcf7_form_title_attr', $options['html_title'] );
+		if ( '' === $title_attr ) {
+			/* translators: default accessible name of the form */
+			$title_attr = __( 'Contact', 'contact-form-7' );
+		}
 
 		$class = 'wpcf7-form';
 
@@ -643,8 +647,7 @@ class WPCF7_ContactForm {
 			'class' => ( '' !== $class ) ? $class : null,
 			'id' => ( '' !== $id_attr ) ? $id_attr : null,
 			'name' => ( '' !== $name_attr ) ? $name_attr : null,
-			'aria-label' => ( '' !== $title_attr )
-				? $title_attr : __( 'Contact form', 'contact-form-7' ),
+			'aria-label' => $title_attr,
 			'enctype' => ( '' !== $enctype ) ? $enctype : null,
 			'autocomplete' => ( '' !== $autocomplete ) ? $autocomplete : null,
 			'novalidate' => true,


### PR DESCRIPTION
> Do NOT include a WAI-ARIA role name in the accessible name. For example, do not include the word button in the name of a button, the word image in the name of an image, or the word navigation in the name of a navigation region. Doing so would create duplicate screen reader output since screen readers convey the role of an element in addition to its name.

Source: [W3C ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#composingeffectiveanduser-friendlyaccessiblenames)