### PR TITLE
Proposal for CleanTalk Anti-Spam Integration with Contact Form 7

### DIFF
--- a/load.php
+++ b/load.php
@@ -66,6 +66,7 @@ class WPCF7 {
 		self::load_module( 'text' );
 		self::load_module( 'textarea' );
 		self::load_module( 'turnstile' );
+		self::load_module( 'cleantalk' );
 	}
 
 

--- a/modules/cleantalk/cleantalk.php
+++ b/modules/cleantalk/cleantalk.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * CleanTalk module main file
+ *
+ * @link https://cleantalk.org
+ */
+
+wpcf7_include_module_file( 'cleantalk/service.php' );
+
+
+add_action( 'wpcf7_init', 'wpcf7_cleantalk_register_service', 40, 0 );
+
+/**
+ * Registers the CleanTalk service.
+ */
+function wpcf7_cleantalk_register_service() {
+	$integration = WPCF7_Integration::get_instance();
+
+	$integration->add_service( 'cleantalk',
+		WPCF7_CleanTalk::get_instance()
+	);
+}
+
+
+add_action(
+	'wp_enqueue_scripts',
+	'wpcf7_cleantalk_enqueue_scripts',
+	20, 0
+);
+
+/**
+ * Enqueues frontend scripts for CleanTalk.
+ */
+function wpcf7_cleantalk_enqueue_scripts() {
+	$service = WPCF7_CleanTalk::get_instance();
+
+	if ( ! $service->is_active() || \CleanTalkCF7SDK\CleanTalkSDK::isCleantalkPluginActive() ) {
+		return;
+	}
+
+	\CleanTalkCF7SDK\CleanTalkSDK::wpEnqueuePublicScriptBotDetector();
+}
+
+add_filter( 'wpcf7_spam', 'wpcf7_cleantalk_verify_response', 9, 2 );
+
+/**
+ * Check for spam with CleanTalk service.
+ */
+function wpcf7_cleantalk_verify_response( $spam, $submission ) {
+	if ( $spam ) {
+		return $spam;
+	}
+
+	$service = WPCF7_CleanTalk::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return $spam;
+	}
+
+	$cleantalk_is_spam = $service->verify();
+
+	if ( '' === $service->cleantalk_sdk->cleantalk_message->event_token ) {
+		$submission->add_spam_log(array(
+			                          'agent'  => 'cleantalk',
+			                          'reason' => __(
+				                          'CleanTalk event token field is empty. Probably user has no JavaScript enabled.',
+				                          'contact-form-7'
+			                          ),
+		                          ));
+	}
+
+	if ( $cleantalk_is_spam ) { // Human
+		$spam = false;
+	} else { // Bot
+		$spam = true;
+		$submission->add_spam_log(array(
+			                          'agent'  => 'cleantalk',
+			                          'reason' => sprintf(
+				                          __(
+					                          'CleanTalk detected spam, server comment: %1$s',
+					                          'contact-form-7'
+				                          ),
+				                          $service->get_cleantalk_server_comment()
+			                          ),
+		                          ));
+	}
+
+	return $spam;
+}
+
+add_action( 'wpcf7_admin_menu', 'wpcf7_admin_init_cleantalk', 10, 0 );
+
+/**
+ * Adds filters and actions for warnings.
+ */
+function wpcf7_admin_init_cleantalk() {
+	if ( ! WPCF7::get_option( 'cleantalk_warning' ) ) {
+		return;
+	}
+
+	add_filter(
+		'wpcf7_admin_menu_change_notice',
+		'wpcf7_admin_menu_change_notice_cleantalk',
+		10, 1
+	);
+
+	add_action(
+		'wpcf7_admin_warnings',
+		'wpcf7_admin_warnings_cleantalk',
+		5, 3
+	);
+}
+
+
+/**
+ * Increments the admin menu counter for the Integration page.
+ */
+function wpcf7_admin_menu_change_notice_cleantalk( $counts ) {
+	$counts['wpcf7-integration'] += 1;
+	return $counts;
+}
+
+
+/**
+ * Prints warnings on the admin screen.
+ */
+function wpcf7_admin_warnings_cleantalk( $page, $action, $object ) {
+	if ( 'wpcf7-integration' !== $page ) {
+		return;
+	}
+
+	$service = WPCF7_CleanTalk::get_instance();
+
+	if ( !$service->is_active() ) {
+		$message = sprintf(
+			esc_html(
+				__(
+					"CleanTalk access key is invalid or expired. Please, visit your %s to get a valid key ",
+					'contact-form-7'
+				)
+			),
+			wpcf7_link(
+				$service->cleantalk_sdk::getCleanTalkUTMLink($service->vendor_agent,'my'),
+				__( 'CleanTalk Dashboard', 'contact-form-7' )
+			)
+		);
+
+		wp_admin_notice( $message, array( 'type' => 'warning' ) );
+	}
+}

--- a/modules/cleantalk/cleantalk_wordpress_sdk.php
+++ b/modules/cleantalk/cleantalk_wordpress_sdk.php
@@ -1,0 +1,742 @@
+<?php
+
+/**
+ * DO NOT FORGET TO USE YOUR OWN NAMESPACE
+ */
+
+namespace CleanTalkCF7SDK;
+
+defined('ABSPATH') || exit;
+
+/**
+ * CleanTalk WordPress SDK for spam protection
+ *
+ * Provides integration with CleanTalk's anti-spam services including:
+ * - API key management
+ * - Spam checking
+ * - Bot detection
+ */
+class CleanTalkSDK
+{
+	/**
+	 * SDK identifier name
+	 */
+	const SDK_NAME = 'cleantalk_wordpress_sdk';
+
+	/**
+	 * Current SDK version
+	 */
+	const SDK_VERSION = '0.1.1';
+
+	/**
+	 * WordPress option name for storing the access key
+	 */
+	const STORAGE_ACCES_KEY_NAME = 'cleantalk_wordpress_sdk_key';
+
+	/**
+	 * URL for CleanTalk's bot detector script
+	 */
+	const BOT_DETECTOR_SCRIPT_URL = 'https://moderate.cleantalk.org/ct-bot-detector-wrapper.js';
+
+	/**
+	 * CleanTalk API access key
+	 * @var string
+	 */
+	private $access_key = '';
+
+	/**
+	 * Message data transfer object
+	 * @var CleantalkMessageSDK
+	 */
+	public $cleantalk_message;
+
+	/**
+	 * Response data transfer object
+	 * @var CleantalkResponseSDK
+	 */
+	public $cleantalk_response;
+
+	/**
+	 * Vendor agent
+	 * @var string
+	 */
+	protected $vendor_agent;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $vendor_agent_prefix CleanTalk API access key
+	 * @param string $vendor_version CleanTalk API access key
+	 * @param string|null $access_key CleanTalk API access key
+	 * @param bool $load_scripts Whether to load public scripts
+	 */
+	public function __construct($vendor_agent_prefix, $vendor_version, $access_key = null, $load_scripts = true)
+	{
+		add_action('wp_ajax_apbct_sdk_key_form', array($this, 'sync'));
+		$load_scripts && $this->wpLoadPublicScripts();
+		$this->cleantalk_response = new CleantalkResponseSDK();
+		$vendor_agent_prefix      = !empty($vendor_agent_prefix) && is_string($vendor_agent_prefix) ? $vendor_agent_prefix : 'unknown_vendor';
+		$vendor_agent_version      = !empty($vendor_version) && is_string($vendor_version) ? $vendor_version : '1.0.0';
+		$this->vendor_agent       = 'wordpress-' . $vendor_agent_prefix . '-' . $vendor_agent_version;
+		$this->setAccessKey($access_key, ! empty($access_key));
+	}
+
+	/**
+	 * Load public scripts if conditions are met
+	 */
+	public function wpLoadPublicScripts()
+	{
+		if ( static::storageGetAccessKey() && ! static::isCleantalkPluginActive() ) {
+			add_action('wp_head', array($this, 'printPublicScriptBotDetector'));
+		}
+	}
+
+	/**
+	 * Set the access key for this instance, if second arg is true, this will save the key to storage
+	 *
+	 * @param string|null $access_key CleanTalk API access key
+	 * @param bool $save_key_to_storage
+	 */
+	public function setAccessKey($access_key, $save_key_to_storage = true)
+	{
+		if ( is_string($access_key) && ! empty($access_key) ) {
+			$this->access_key = $access_key;
+			$save_key_to_storage && self::storageUpdateAccessKey($access_key);
+		}
+	}
+
+	/**
+	 * Synchronize and validate the access key with CleanTalk servers
+	 *
+	 * @param string|null $input_key Key to validate
+	 * @param bool $direct_call Whether this is a direct call (not AJAX)
+	 * @param bool $save_key_to_storage Do save key
+	 *
+	 * @return array|null Returns array if direct_call, otherwise sends JSON response
+	 */
+	public function sync($input_key = null, $direct_call = false, $save_key_to_storage = true)
+	{
+		if ( empty($input_key) ) {
+			$key = isset($_POST[static::STORAGE_ACCES_KEY_NAME]) && is_string($_POST[static::STORAGE_ACCES_KEY_NAME])
+				? sanitize_text_field($_POST[static::STORAGE_ACCES_KEY_NAME])
+				: '';
+		} else {
+			$key = $input_key;
+		}
+
+		$result = [
+			'success' => false,
+			'message' => '',
+		];
+
+		if ( empty($key) ) {
+			$save_key_to_storage && self::storageUpdateAccessKey('');
+			$result['success'] = ! $direct_call;
+			$result['message'] = 'key is empty';
+
+			return self::formatSyncResult($result, $direct_call);
+		}
+
+		try {
+			if (
+				isset($_POST['apbct_sdk_key_form_nonce'])
+				&& is_string($_POST['apbct_sdk_key_form_nonce'])
+				&& ! wp_verify_nonce($_POST['apbct_sdk_key_form_nonce'], 'apbct_sdk_key_form')
+			) {
+				throw new \Exception('nonce is not valid');
+			}
+
+			$response = wp_remote_post('https://api.cleantalk.org/', array(
+				'body' => array(
+					'method_name' => 'notice_paid_till',
+					'auth_key'    => $key,
+				),
+			));
+
+			if ( is_wp_error($response) || ! $response ) {
+				throw new \Exception(wp_remote_retrieve_response_message($response));
+			}
+
+			$body = wp_remote_retrieve_body($response);
+			if ( empty($body) ) {
+				throw new \Exception('content not found');
+			}
+
+			$response_code = wp_remote_retrieve_response_code($response);
+			if ( $response_code >= 400 ) {
+				$msg = '';
+				if ( $response instanceof \WP_Error ) {
+					$msg = $response->get_error_message();
+				} elseif ( is_object($response) && isset($response->detail) ) {
+					$msg = $response->detail;
+				}
+				throw new \Exception('response code error: ' . $response_code . ' - ' . $msg);
+			}
+
+			$response = json_decode($body);
+			if ( is_null($response) ) {
+				throw new \Exception('decoded response null');
+			}
+
+			if ( isset($response->data->valid) && $response->data->valid == 0 ) {
+				throw new \Exception('key is not valid');
+			}
+
+			if ( isset($response->data->product_id) && $response->data->product_id != 1 ) {
+				throw new \Exception('key is not for Anti-Spam service');
+			}
+
+			if ( isset($response->data->moderate) && $response->data->moderate == 0 ) {
+				throw new \Exception('service disabled, check key license');
+			}
+		} catch (\Exception $e) {
+			$result['message'] = $e->getMessage();
+
+			return self::formatSyncResult($result, $direct_call);
+		}
+
+		$save_key_to_storage && self::storageUpdateAccessKey($key);
+
+		$result['success'] = true;
+
+		return self::formatSyncResult($result, $direct_call);
+	}
+
+	/**
+	 * Format the synchronization result for response
+	 *
+	 * @param array $result Result array with success and message
+	 * @param bool $direct_call Whether this is a direct call
+	 *
+	 * @return array|void Returns array or sends JSON response
+	 */
+	private static function formatSyncResult($result, $direct_call)
+	{
+		if ( $direct_call ) {
+			return $result;
+		}
+		wp_send_json($result);
+	}
+
+	/**
+	 * Render the API key form HTML
+	 *
+	 * @param string|null $vendor_name
+	 * @return string HTML for the key form
+	 */
+	protected function renderKeyForm($vendor_name = null)
+	{
+		$key            = (string)static::storageGetAccessKey();
+		$agitation      = 'CleanTalk is cloud Anti-Spam service which focuses on a background scoring for websites visitors to highlight legitimate visitors and filter spambots.<br>Click here to get your key and start filter spam bots! <a href="' . static::getCleanTalkUTMLink($vendor_name, 'register') . '" target="_blank">https://cleantalk.org/register</a>';
+		$agitation      = wp_kses(
+			$agitation,
+			array('a' => array('href' => array(), 'target' => array()), 'br' => array())
+		);
+		$key_is_ok_desc = 'Anti-Spam is active, use <a href="' . static::getCleanTalkUTMLink($vendor_name, 'my') . '" target="_blank">Dashboard</a> to tune the service.';
+		$key_is_ok_desc = wp_kses($key_is_ok_desc, array('a' => array('href' => array(), 'target' => array())));
+
+		$message = $key ? $key_is_ok_desc : $agitation;
+
+		return '<p><span class="apbct_sdk_description">' . $message . '</span>
+        . <form id="apbct_sdk-key-form" method="post">'
+		       . '<input type="text" name="' . CleanTalkSDK::STORAGE_ACCES_KEY_NAME . '" value="' . $key . '" placeholder="API key"> <input type="submit" value="Save" class="apbct_sdk_submit">'
+		       . wp_nonce_field(
+			       'apbct_sdk_key_form',
+			       'apbct_sdk_key_form_nonce'
+		       ) . '<input type="hidden" name="action" value="apbct_sdk_key_form">'
+		       . '</form></p>'
+		       . '<script> jQuery(document).ready(function($) {
+            $("form#apbct_sdk-key-form").submit(function(e) {
+                e.preventDefault();
+                $(".apbct_sdk_submit").attr("disabled","disabled").css("cursor", "wait");
+                $.post("' . admin_url('admin-ajax.php') . '", $(this).serialize(), function(response) {
+                    $(".apbct_sdk-error").remove();
+                    $(".apbct_sdk_submit").removeAttr("disabled").removeAttr("style");
+                    if (response.success) {
+                        const message = response.message === "key is empty" ? "' . addslashes($agitation) . '" : "' . addslashes($key_is_ok_desc) . '";
+                        $("input[name=\'apbct_sdk_description\']").html(message);
+                    } else {
+                        $("input[name=\'apbct_sdk_description\']").html("' . addslashes($agitation) . '");
+                        $("input[name=\'' . static::STORAGE_ACCES_KEY_NAME . '\']").parent().after("<div class=\'error apbct_sdk-error\'>" + response.message + "</div>");
+                    }
+                });
+            });
+        });
+        </script>';
+	}
+
+	/**
+	 * Print the bot detector script tag
+	 */
+	public static function printPublicScriptBotDetector()
+	{
+		echo static::getBotDetectorScriptTag();
+	}
+
+	/**
+	 * Get the bot detector script tag HTML
+	 *
+	 * @return string Script tag HTML
+	 */
+	public static function getBotDetectorScriptTag()
+	{
+		return sprintf(
+			'<script src="%s" id="ct_bot_detector-js"></script>',
+			esc_attr(static::getBotDetectorScriptURL())
+		);
+	}
+
+	/**
+	 * Get the URL for the bot detector script
+	 *
+	 * @return string Script URL
+	 */
+	public static function getBotDetectorScriptURL()
+	{
+		return static::BOT_DETECTOR_SCRIPT_URL;
+	}
+
+	/**
+	 * Enqueue the bot detector script in WordPress
+	 * @psalm-suppress InvalidArgument
+	 */
+	public static function wpEnqueuePublicScriptBotDetector()
+	{
+		wp_enqueue_script(
+			self::SDK_NAME . '--bot-detector',
+			static::getBotDetectorScriptURL(),
+			[],
+			self::SDK_VERSION,
+			array(
+				'in_footer' => false,
+				'strategy'  => 'defer'
+			)
+		);
+	}
+
+	/**
+	 * Check if data contains spam. A simple way to get if spam or not.
+	 * Use if you need bool value as result, a do not need anything else.
+	 * Remember, if anything goes wrong with submission, the result become false.
+	 *
+	 * @param CleantalkMessageSDK $cleantalk_sdk_message Data to check
+	 *
+	 * @return bool True if spam detected, false otherwise
+	 */
+	public function isSpam($cleantalk_sdk_message)
+	{
+		$response = $this->getCleanTalkResponse($cleantalk_sdk_message);
+		if ( isset($response->allow) && $response->allow == 0 ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get response from CleanTalk servers for data check
+	 *
+	 * @param CleantalkMessageSDK $cleantalk_sdk_message Data to check
+	 *
+	 * @return CleantalkResponseSDK Response object
+	 */
+	public function getCleanTalkResponse($cleantalk_sdk_message)
+	{
+		global $cleantalk_executed;
+
+		if ( !empty($this->access_key) ) {
+			$work_key = $this->access_key;
+		} else if ( !empty($cleantalk_sdk_message->auth_key) ) {
+			$work_key = $cleantalk_sdk_message->auth_key;
+		} else {
+			$work_key = static::storageGetAccessKey();
+		}
+
+		try {
+			if ( ! $work_key ) {
+				$this->cleantalk_response->skip_reason = 'no access key';
+				throw new \Exception('Request skipped');
+			}
+
+			$skip_reason = apply_filters('cleantalk_sdk_skip_request', '');
+
+			if ( ! empty($skip_reason) ) {
+				$this->cleantalk_response->skip_reason = $skip_reason;
+				throw new \Exception('Request skipped');
+			}
+
+			if ( $cleantalk_executed ) {
+				$this->cleantalk_response->skip_reason = 'cleantalk already executed';
+				throw new \Exception('Request skipped');
+			}
+
+			if ( empty($cleantalk_sdk_message) ) {
+				$this->cleantalk_response->skip_reason = 'empty message';
+				throw new \Exception('Bad params');
+			}
+
+			if ( empty($cleantalk_sdk_message->event_token) ) {
+				$this->cleantalk_response->skip_reason = 'event token is empty';
+				throw new \Exception('Bad params');
+			}
+
+			$response = wp_remote_post('https://moderate.cleantalk.org/api2.0', array(
+				'body' => $cleantalk_sdk_message->getJson(),
+			));
+
+			if ( is_wp_error($response) ) {
+				$this->cleantalk_response->skip_reason = 'wp error occured';
+				throw new \Exception('Request failed');
+			}
+
+			$body = wp_remote_retrieve_body($response);
+			if ( empty($body) ) {
+				$this->cleantalk_response->skip_reason = 'empty response body';
+				throw new \Exception('Request failed');
+			}
+
+			$this->cleantalk_response->data = $body;
+
+			$response_code = wp_remote_retrieve_response_code($response);
+			if ( $response_code >= 400 ) {
+				$this->cleantalk_response->skip_reason = 'response code >400';
+				throw new \Exception('Request failed');
+			}
+
+			$response = json_decode($body);
+			if ( is_null($response) ) {
+				$this->cleantalk_response->skip_reason = 'cannot decode response JSON';
+				throw new \Exception('Request failed');
+			}
+
+			if ( ! (isset($response->allow, $response->comment)) ) {
+				$this->cleantalk_response->skip_reason = 'unknown response format';
+				throw new \Exception('Request failed');
+			}
+
+			$cleantalk_executed                = true;
+			$this->cleantalk_response->allow   = $response->allow;
+			$this->cleantalk_response->comment = $response->comment;
+			$this->cleantalk_response->success = true;
+		} catch (\Exception $e) {
+			$this->cleantalk_response->skip_reason = $e->getMessage() . ': ' . $this->cleantalk_response->skip_reason;
+		}
+
+		return $this->cleantalk_response;
+	}
+
+	/**
+	 * Gather default parameters for CleanTalk API request
+	 *
+	 * @param array $data Input data
+	 * @param string|null $work_key Optional API key
+	 *
+	 * @return CleantalkMessageSDK Parameters for API request in JSON format
+	 */
+	public function getDefaultHTTPMessage($data, $work_key)
+	{
+		$email_pattern = '/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/';
+		$email         = null;
+
+		array_walk_recursive($data, function ($value) use (&$email, $email_pattern) {
+			if ( is_string($value) && preg_match($email_pattern, $value, $matches) ) {
+				$email = $matches[0];
+			}
+		});
+
+		if ( function_exists('apache_request_headers') ) {
+			$all_headers = array_filter(
+				apache_request_headers(),
+				function ($value, $key) {
+					return strtolower($key) !== 'cookie';
+				},
+				ARRAY_FILTER_USE_BOTH
+			);
+		}
+
+		//message details
+		$message = [];
+
+		$message['sender_ip'] = isset($_SERVER['REMOTE_ADDR'])
+			? $_SERVER['REMOTE_ADDR']
+			: '';
+
+		$message['x_forwarded_for'] = isset($_SERVER['HTTP_X_FORWARDED_FOR'])
+			? $_SERVER['HTTP_X_FORWARDED_FOR']
+			: null;
+
+		$message['x_real_ip'] = isset($_SERVER['HTTP_X_REAL_IP'])
+			? $_SERVER['HTTP_X_REAL_IP']
+			: null;
+
+		$message['auth_key'] = ! empty($work_key)
+			? $work_key
+			: '';
+
+		$message['agent'] = empty($this->vendor_agent)
+			? self::SDK_NAME . '_' . self::SDK_VERSION
+			: $this->vendor_agent;
+
+		$message['sender_email'] = $email;
+
+		$message['event_token'] = ! empty($data['ct_bot_detector_event_token'])
+			? $data['ct_bot_detector_event_token']
+			: '';
+
+		$message['all_headers'] = ! empty($all_headers)
+			? json_encode($all_headers)
+			: '';
+
+		//sender info
+		$message['referrer'] = isset($_SERVER['HTTP_REFERER'])
+			? $_SERVER['HTTP_REFERER']
+			: '';
+		$message['user_agent'] = isset($_SERVER['HTTP_USER_AGENT'])
+			? $_SERVER['HTTP_USER_AGENT']
+			: '';
+		$message['sdk_version'] = self::SDK_VERSION;
+
+		$this->cleantalk_message = new CleantalkMessageSDK($message);
+
+		return $this->cleantalk_message;
+	}
+
+	/**
+	 * Check if CleanTalk plugin is active
+	 *
+	 * @return bool True if plugin active, false otherwise
+	 */
+	public static function isCleantalkPluginActive()
+	{
+		return defined('APBCT_VERSION');
+	}
+
+	/**
+	 * Update the stored access key
+	 *
+	 * @param string $access_key API key to store
+	 */
+	protected static function storageUpdateAccessKey($access_key)
+	{
+		update_option(static::STORAGE_ACCES_KEY_NAME, $access_key);
+	}
+
+	/**
+	 * Get the stored access key
+	 *
+	 * @return string|false The stored key or false if not set
+	 */
+	protected static function storageGetAccessKey()
+	{
+		$key = get_option(static::STORAGE_ACCES_KEY_NAME, '');
+		if ( is_string($key) && ! empty($key) ) {
+			return $key;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string|null $utm_vendor_name UTM campaign source should contain vendor name.
+	 *
+	 * @return string
+	 */
+	public static function getCleanTalkUTMLink($utm_vendor_name, $get_path = '')
+	{
+		$utm = array(
+			'utm_campaign' => is_string($utm_vendor_name) ? $utm_vendor_name : 'unknown_sdk_vendor',
+			'utm_source' => 'admin_panel',
+			'utm_medium' => 'plugin',
+			'utm_content' => 'pluginsettings',
+		);
+		$utm = http_build_query($utm);
+		$href = 'https://cleantalk.org/' . $get_path . '/' . $utm;
+		return esc_url($href);
+	}
+}
+
+/**
+ * Data Transfer Object for messages to CleanTalk
+ */
+class CleantalkMessageSDK
+{
+	/**
+	 * Sender IP address
+	 * @var string
+	 */
+	public $sender_ip = '';
+	/**
+	 * X-Forwarded-For header value
+	 * @var string
+	 */
+	public $x_forwarded_for = '';
+	/**
+	 * X-Real-IP header value
+	 * @var string
+	 */
+	public $x_real_ip = '';
+	/**
+	 * API authentication key
+	 * @var string
+	 */
+	public $auth_key = '';
+	/**
+	 * User agent string
+	 * @var string
+	 */
+	public $agent = '';
+	/**
+	 * Sender email address
+	 * @var string
+	 */
+	public $sender_email = '';
+	/**
+	 * Sender nickname
+	 * @var string
+	 */
+	public $sender_nickname = '';
+	/**
+	 * Event token for bot detection
+	 * @var string
+	 */
+	public $event_token = '';
+	/**
+	 * All request headers as JSON
+	 * @var string
+	 */
+	public $all_headers = '';
+	/**
+	 * Sender info. Referrer.
+	 * @var string
+	 */
+	public $referrer = '';
+	/**
+	 * Sender info. UA.
+	 * @var string
+	 */
+	public $user_agent = '';
+	/**
+	 * Sender info. Visitor message.
+	 * @var string
+	 */
+	public $message = '';
+	/**
+	 * JSON encoded string of sender info, including referrer, user agent, and message.
+	 * @var string
+	 */
+	private $sender_info = '';
+	/**
+	 * @var bool is the request is registration
+	 */
+	public $registration_flag = false;
+	/**
+	 * @var string SDK version
+	 */
+	private $sdk_version = '';
+	/**
+	 * @var string misc service data
+	 */
+	private $post_info = '';
+	/**
+	 * @var string the API method for spam checking
+	 */
+	private $method_name = 'check_message';
+
+	/**
+	 * Constructor - initializes sender_info
+	 */
+	public function __construct($params)
+	{
+		foreach ( $params as $param_name => $param ) {
+			if ( property_exists(static::class, $param_name) ) {
+				$type              = gettype($this->$param_name);
+				$this->$param_name = $param;
+				settype($this->$param_name, $type);
+			}
+		}
+		$this->prepareServiceData();
+	}
+
+	/**
+	 * Service method. Prepare sender_info, post_info and method name.
+	 * @return void
+	 */
+	public function prepareServiceData()
+	{
+		//prepare sender info
+		$this->sender_info = json_encode(
+			[
+				'REFFERRER'  => $this->referrer,
+				'user_agent' => $this->user_agent,
+				'sdk_version' => $this->sdk_version,
+			]
+		);
+		//prepare method name
+		$this->method_name = $this->registration_flag ? 'check_newuser' : 'check_message';
+
+		//prepare post info
+		$comment_type = $this->registration_flag ? 'sdk_registration' : 'sdk_contact_form';
+		$this->post_info = json_encode(
+			[
+				'comment_type' => $comment_type . '_' . $this->agent
+			]
+		);
+	}
+
+	/**
+	 * Get all properties as array
+	 *
+	 * @return array Message data as associative array
+	 */
+	public function getArray()
+	{
+		$this->prepareServiceData();
+		return get_object_vars($this);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getJson()
+	{
+		$json = json_encode($this->getArray());
+
+		return false !== $json ? $json : '';
+	}
+}
+
+/**
+ * Data Transfer Object for CleanTalk response
+ */
+class CleantalkResponseSDK
+{
+	/**
+	 * Whether to allow the request (1 = allow, 0 = block)
+	 * @var int
+	 */
+	public $allow = 1;
+
+	/**
+	 * Response comment/message
+	 * @var string
+	 */
+	public $comment = 'Not spam';
+
+	/**
+	 * Raw response data
+	 * @var string
+	 */
+	public $data = '';
+
+	/**
+	 * Reason for skipping check
+	 * @var string
+	 */
+	public $skip_reason = '';
+
+	/**
+	 * Whether request succeeded
+	 * @var bool
+	 */
+	public $success = false;
+}

--- a/modules/cleantalk/service.php
+++ b/modules/cleantalk/service.php
@@ -1,0 +1,279 @@
+<?php
+
+if ( ! class_exists( 'WPCF7_Service' ) ) {
+	return;
+}
+
+require_once WPCF7_PLUGIN_DIR . '/modules/cleantalk/cleantalk_wordpress_sdk.php';
+
+class WPCF7_CleanTalk extends WPCF7_Service {
+
+	private static $instance;
+	private $access_key;
+	private $key_verified = false;
+	/**
+	 * @var CleanTalkCF7SDK\CleanTalkSDK
+	 */
+	public $cleantalk_sdk;
+	public $vendor_agent = 'contactform7';
+	public $vendor_version = WPCF7_VERSION;
+
+	public static function get_instance() {
+		if ( empty( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	private function __construct() {
+		$this->access_key = WPCF7::get_option('cleantalk');
+		$this->cleantalk_sdk = new CleanTalkCF7SDK\CleanTalkSDK(
+			$this->vendor_agent,
+			$this->vendor_version,
+			null,
+			false
+		);
+	}
+
+
+	public function get_title() {
+		return __( 'CleanTalk', 'contact-form-7' );
+	}
+
+
+	public function is_active() {
+		$sitekey = $this->get_access_key();
+		return $sitekey;
+	}
+
+
+	public function get_categories() {
+		return array( 'spam_protection' );
+	}
+
+
+	public function icon() {
+	}
+
+
+	public function link() {
+		echo wpcf7_link(
+			$this->cleantalk_sdk::getCleanTalkUTMLink($this->vendor_agent, 'my'),
+			'CleanTalk Dashboard'
+		);
+	}
+
+
+	public function get_access_key() {
+		if ( empty( $this->access_key ) ) {
+			return false;
+		}
+
+		return $this->access_key;
+	}
+
+
+	public function verify( ) {
+		$is_human = false;
+
+		$this->cleantalk_sdk->setAccessKey($this->get_access_key(), false);
+
+		$form_data = WPCF7_Submission::get_instance()->get_posted_data();
+
+		$custom_sdk_message = $this->cleantalk_sdk->getDefaultHTTPMessage($form_data, $this->get_access_key());
+
+		$custom_sdk_message->message = !empty($form_data['your-message'])
+			? (!is_scalar($form_data['your-message'])
+				? serialize($form_data['your-message'])
+				: $form_data['your-message'])
+			: null;
+		$cleantalk_response = $this->cleantalk_sdk->getCleanTalkResponse($custom_sdk_message);
+
+		if (1 == $cleantalk_response->allow) {
+			$is_human = true;
+		} else {
+			add_filter('wpcf7_display_message', array($this, 'filter_display_message'), 20, 1);
+		}
+
+		if ( $submission = WPCF7_Submission::get_instance() ) {
+			$submission->push( 'cleantalk', array(
+				'version' => CleanTalkCF7SDK\CleanTalkSDK::SDK_VERSION,
+				'comment' => $this->cleantalk_sdk->cleantalk_response->comment
+			) );
+		}
+
+		return $is_human;
+	}
+
+	public function filter_display_message($message, $status = 'spam') {
+		if ($status === 'spam') {
+			$message = $this->cleantalk_sdk->cleantalk_response->comment;
+		}
+		return $message;
+	}
+
+
+	public function get_cleantalk_server_comment() {
+		return $this->cleantalk_sdk->cleantalk_response->comment;
+	}
+
+
+	protected function menu_page_url( $args = '' ) {
+		$args = wp_parse_args( $args, array() );
+
+		$url = menu_page_url( 'wpcf7-integration', false );
+		$url = add_query_arg( array( 'service' => 'cleantalk' ), $url );
+
+		if ( ! empty( $args ) ) {
+			$url = add_query_arg( $args, $url );
+		}
+
+		return $url;
+	}
+
+
+	protected function save_data() {
+		WPCF7::update_option( 'cleantalk', $this->access_key );
+	}
+
+
+	protected function reset_data() {
+		$this->access_key = null;
+		$this->save_data();
+	}
+
+
+	public function load( $action = '' ) {
+		if ( 'setup' === $action and 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+			check_admin_referer( 'wpcf7-cleantalk-setup' );
+
+			if ( ! empty( $_POST['reset'] ) ) {
+				$this->reset_data();
+				$redirect_to = $this->menu_page_url( 'action=setup' );
+			} else {
+				$input_site_key = trim(isset($_POST['sitekey']) ? $_POST['sitekey'] : '');
+				$this->validate_access_key($input_site_key);
+				$input_site_key = $this->key_verified ? $input_site_key : '';
+				if ( $input_site_key ) {
+					$this->access_key = $input_site_key;
+					$this->save_data();
+					$redirect_to = $this->menu_page_url(
+						array(
+							'message' => 'success',
+						)
+					);
+				} else {
+					$redirect_to = $this->menu_page_url( array(
+						'action' => 'setup',
+						'message' => 'invalid',
+					) );
+					WPCF7::update_option('cleantalk_warning', 'CUSTOM');
+				}
+			}
+
+			if ( $this->key_verified && WPCF7::get_option('cleantalk_warning' ) ) {
+				WPCF7::update_option( 'cleantalk_warning', false );
+			}
+
+			wp_safe_redirect( $redirect_to );
+			exit();
+		}
+	}
+
+
+	public function admin_notice( $message = '' ) {
+		if ( 'invalid' === $message ) {
+			wp_admin_notice(
+				sprintf(
+					'<strong>%1$s</strong>: %2$s',
+					esc_html( __( "Error", 'contact-form-7' ) ),
+					esc_html( __( "Invalid key values.", 'contact-form-7' ) )
+				),
+				array( 'type' => 'error' )
+			);
+		}
+
+		if ( 'success' === $message ) {
+			wp_admin_notice(
+				esc_html( __( "Settings saved.", 'contact-form-7' ) ),
+				array( 'type' => 'success' )
+			);
+		}
+	}
+
+
+	public function display( $action = '' ) {
+		echo sprintf(
+			'<p>%s</p>',
+			esc_html( __( "CleanTalk eliminates the need for CAPTCHA, questions&answers and other ways which use complicated communication methods for spam protection on your site. Invisible to the visitors, spam protection has a positive effect on the loyalty of the site's audience.", 'contact-form-7' ) )
+		);
+
+		if ( $this->is_active() ) {
+			echo sprintf(
+				'<p class="dashicons-before dashicons-yes">%s</p>',
+				esc_html( __( "CleanTalk is active on this site.", 'contact-form-7' ) )
+			);
+		}
+
+		if ( 'setup' === $action ) {
+			$this->display_setup();
+		} else {
+			echo sprintf(
+				'<p><a href="%1$s" class="button">%2$s</a></p>',
+				esc_url( $this->menu_page_url( 'action=setup' ) ),
+				esc_html( __( 'Setup Integration', 'contact-form-7' ) )
+			);
+		}
+	}
+
+	private function validate_access_key($access_key)
+	{
+		$validation_result  = $this->cleantalk_sdk->sync($access_key, true);
+		$this->key_verified = !empty($validation_result['success']);
+		if (!$this->key_verified) {
+			WPCF7_CleanTalk::get_instance()->reset_data();
+		}
+	}
+
+
+	private function display_setup() {
+		$sitekey = $this->get_access_key();
+?>
+<form method="post" action="<?php echo esc_url( $this->menu_page_url( 'action=setup' ) ); ?>">
+<?php wp_nonce_field( 'wpcf7-cleantalk-setup' ); ?>
+<table class="form-table">
+<tbody>
+<tr>
+	<th scope="row"><label for="sitekey"><?php echo esc_html( __( 'CleanTalk Access Key', 'contact-form-7' ) ); ?></label></th>
+	<td><?php
+		if ( $this->is_active() ) {
+			echo esc_html( $sitekey );
+			echo sprintf(
+				'<input type="hidden" value="%1$s" id="sitekey" name="sitekey" />',
+				esc_attr( $sitekey )
+			);
+		} else {
+			echo sprintf(
+				'<input type="text" aria-required="true" value="%1$s" id="sitekey" name="sitekey" class="regular-text code" />',
+				esc_attr( $sitekey )
+			);
+		}
+	?></td>
+</tr>
+</tbody>
+</table>
+<?php
+		if ( $this->is_active() ) {
+			submit_button(
+				_x( 'Remove Key', 'API key', 'contact-form-7' ),
+				'small', 'reset'
+			);
+		} else {
+			submit_button( __( 'Save Changes', 'contact-form-7' ) );
+		}
+?>
+</form>
+<?php
+	}
+}


### PR DESCRIPTION
Dear Mr. Miyoshi,

I hope this message finds you well.

My name is Alex Gull, and I am the Extension Developer at [CleanTalk Inc](https://cleantalk.org/). For over a decade, our company has specialized in providing robust anti-spam solutions to users worldwide.

First, I would like to express my sincere admiration for your work on the Contact Form 7 plugin. Your plugin has revolutionized contact form management for millions of WordPress users, and we deeply respect your commitment to simplicity and quality.

### Why This Matters to Us
At CleanTalk, we actively maintain and develop our anti-spam service for WordPress sites through a dedicated plugin, which already includes built-in integration with Contact Form 7. However, we recognize that many CF7 users may not have our plugin installed. By integrating CleanTalk’s anti-spam protection directly into CF7, we aim to extend the benefits of our service to all users - even those who rely solely on your plugin. This would provide seamless, invisible spam protection without requiring additional installations or configurations.

### Our Proposal
We believe that providing your users with additional anti-spam options aligns perfectly with Contact Form 7’s philosophy of being lightweight yet powerful. CleanTalk’s invisible protection eliminates the need for CAPTCHAs or user interaction, reducing friction for visitors while maintaining robust security. This integration would:
- Enhance CF7’s appeal to developers and site owners who prioritize both security and user experience.
- Preserve CF7’s core values by adding zero overhead or complexity.
- Offer flexibility as an optional module, ensuring users can choose the anti-spam method that suits their needs.

To support CF7’s ecosystem, we’re committed to:
- Clear attribution in our documentation, linking back to Contact Form 7.
- Promoting CF7 as a flexible, developer-friendly solution in our communications.

Key Features of the Integration:
- Maintains CF7’s simplicity and UI integrity.
- Imposes no additional load or complexity on your plugin.
- Fully supported and maintained by our dedicated team.

### How It Works:
1. Users enable CleanTalk by entering their API key in the module settings.
2. Form submissions are intercepted via the wpcf7_spam hook.
3. Using POST data and JavaScript-collected metrics, our cloud service determines whether the submission is spam.
4. Spam submissions are blocked, with a clear reason displayed to the user.
5. Legitimate submissions proceed uninterrupted.
6. Our cloud solution boasts high accuracy and continuous improvement. Learn more [here](https://cleantalk.org/anti-spam-plugins-for-websites).
7. A personalized Dashboard provides insights into blocked/allowed submissions.

We’ve prepared a pull request for your review and would be honored to incorporate your feedback. Our team is eager to collaborate closely to ensure this integration meets your standards.

Thank you for your time and consideration. We look forward to your thoughts and hope for the opportunity to work together.

Warm regards,
Alex Gull
Extension Developer, CleanTalk Inc