### PR TITLE
Fix capitalization in integration setup button text

### DIFF
--- a/modules/stripe/service.php
+++ b/modules/stripe/service.php
@@ -216,7 +216,7 @@ class WPCF7_Stripe extends WPCF7_Service {
 			) );
 
 			$formatter->append_preformatted(
-				esc_html( __( 'Setup Integration', 'contact-form-7' ) )
+				esc_html( __( 'Setup integration', 'contact-form-7' ) )
 			);
 
 			$formatter->end_tag( 'p' );


### PR DESCRIPTION
Changed 'Setup Integration' to 'Setup integration' for consistency in UI text capitalization.