### PR TITLE
Declare class constant visibility explicitly

### DIFF
--- a/includes/config-validator/validator.php
+++ b/includes/config-validator/validator.php
@@ -17,9 +17,9 @@ class WPCF7_ConfigValidator {
 	/**
 	 * The plugin version in which important updates happened last time.
 	 */
-	const last_important_update = '5.8.1';
+	public const last_important_update = '5.8.1';
 
-	const error_codes = array(
+	public const error_codes = array(
 		'maybe_empty',
 		'invalid_mailbox_syntax',
 		'email_not_in_site_domain',

--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -5,7 +5,7 @@ class WPCF7_ContactForm {
 	use WPCF7_SWV_SchemaHolder;
 	use WPCF7_PipesHolder;
 
-	const post_type = 'wpcf7_contact_form';
+	public const post_type = 'wpcf7_contact_form';
 
 	private static $found_items = 0;
 	private static $current = null;

--- a/includes/html-formatter.php
+++ b/includes/html-formatter.php
@@ -6,27 +6,27 @@
 class WPCF7_HTMLFormatter {
 
 	// HTML component types.
-	const text = 0;
-	const start_tag = 1;
-	const end_tag = 2;
-	const comment = 3;
+	public const text = 0;
+	public const start_tag = 1;
+	public const end_tag = 2;
+	public const comment = 3;
 
 	/**
 	 * Tag name reserved for a custom HTML element used as a block placeholder.
 	 */
-	const placeholder_block = 'placeholder:block';
+	public const placeholder_block = 'placeholder:block';
 
 	/**
 	 * Tag name reserved for a custom HTML element used as an inline placeholder.
 	 */
-	const placeholder_inline = 'placeholder:inline';
+	public const placeholder_inline = 'placeholder:inline';
 
 	/**
 	 * The void elements in HTML.
 	 *
 	 * @link https://developer.mozilla.org/en-US/docs/Glossary/Void_element
 	 */
-	const void_elements = array(
+	public const void_elements = array(
 		'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
 		'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr',
 		self::placeholder_block, self::placeholder_inline,
@@ -35,14 +35,14 @@ class WPCF7_HTMLFormatter {
 	/**
 	 * HTML elements that can be a direct child of the same element.
 	 */
-	const nestable_elements = array(
+	public const nestable_elements = array(
 		'article', 'aside', 'blockquote', 'div', 'fieldset', 'section', 'span',
 	);
 
 	/**
 	 * HTML elements that can contain flow content.
 	 */
-	const p_parent_elements = array(
+	public const p_parent_elements = array(
 		'address', 'article', 'aside', 'blockquote', 'body', 'caption',
 		'dd', 'details', 'dialog', 'div', 'dt', 'fieldset', 'figcaption',
 		'figure', 'footer', 'form', 'header', 'li', 'main', 'nav',
@@ -53,7 +53,7 @@ class WPCF7_HTMLFormatter {
 	 * HTML elements that can be neither the parent nor a child of
 	 * a paragraph element.
 	 */
-	const p_nonparent_elements = array(
+	public const p_nonparent_elements = array(
 		'colgroup', 'dl', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head',
 		'hgroup', 'html', 'legend', 'menu', 'ol', 'pre', 'style', 'summary',
 		'table', 'tbody', 'template', 'tfoot', 'thead', 'title', 'tr', 'ul',
@@ -63,7 +63,7 @@ class WPCF7_HTMLFormatter {
 	 * HTML elements in the phrasing content category, plus non-phrasing
 	 * content elements that can be grandchildren of a paragraph element.
 	 */
-	const p_child_elements = array(
+	public const p_child_elements = array(
 		'a', 'abbr', 'area', 'audio', 'b', 'bdi', 'bdo', 'br', 'button',
 		'canvas', 'cite', 'code', 'data', 'datalist', 'del', 'dfn',
 		'em', 'embed', 'i', 'iframe', 'img', 'input', 'ins', 'kbd',
@@ -79,7 +79,7 @@ class WPCF7_HTMLFormatter {
 	/**
 	 * HTML elements that can contain phrasing content.
 	 */
-	const br_parent_elements = array(
+	public const br_parent_elements = array(
 		'a', 'abbr', 'address', 'article', 'aside', 'audio', 'b', 'bdi',
 		'bdo', 'blockquote', 'button', 'canvas', 'caption', 'cite', 'code',
 		'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div',

--- a/includes/mail-tag.php
+++ b/includes/mail-tag.php
@@ -108,9 +108,9 @@ use Contactable\SWV;
  */
 class WPCF7_MailTag_OutputCalculator {
 
-	const email = 0b100;
-	const text = 0b010;
-	const blank = 0b001;
+	public const email = 0b100;
+	public const text = 0b010;
+	public const blank = 0b001;
 
 	private $contact_form;
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -12,7 +12,7 @@ add_action(
 
 class WPCF7_REST_Controller {
 
-	const route_namespace = 'contact-form-7/v1';
+	public const route_namespace = 'contact-form-7/v1';
 
 	public function register_routes() {
 

--- a/includes/swv/php/rules/all.php
+++ b/includes/swv/php/rules/all.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class AllRule extends CompositeRule {
 
-	const rule_name = 'all';
+	public const rule_name = 'all';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/any.php
+++ b/includes/swv/php/rules/any.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class AnyRule extends CompositeRule {
 
-	const rule_name = 'any';
+	public const rule_name = 'any';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/date.php
+++ b/includes/swv/php/rules/date.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class DateRule extends Rule {
 
-	const rule_name = 'date';
+	public const rule_name = 'date';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/dayofweek.php
+++ b/includes/swv/php/rules/dayofweek.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class DayofweekRule extends Rule {
 
-	const rule_name = 'dayofweek';
+	public const rule_name = 'dayofweek';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/email.php
+++ b/includes/swv/php/rules/email.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class EmailRule extends Rule {
 
-	const rule_name = 'email';
+	public const rule_name = 'email';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/enum.php
+++ b/includes/swv/php/rules/enum.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class EnumRule extends Rule {
 
-	const rule_name = 'enum';
+	public const rule_name = 'enum';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/file.php
+++ b/includes/swv/php/rules/file.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class FileRule extends Rule {
 
-	const rule_name = 'file';
+	public const rule_name = 'file';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/maxdate.php
+++ b/includes/swv/php/rules/maxdate.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MaxDateRule extends Rule {
 
-	const rule_name = 'maxdate';
+	public const rule_name = 'maxdate';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/maxfilesize.php
+++ b/includes/swv/php/rules/maxfilesize.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MaxFileSizeRule extends Rule {
 
-	const rule_name = 'maxfilesize';
+	public const rule_name = 'maxfilesize';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/maxitems.php
+++ b/includes/swv/php/rules/maxitems.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MaxItemsRule extends Rule {
 
-	const rule_name = 'maxitems';
+	public const rule_name = 'maxitems';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/maxlength.php
+++ b/includes/swv/php/rules/maxlength.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MaxLengthRule extends Rule {
 
-	const rule_name = 'maxlength';
+	public const rule_name = 'maxlength';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/maxnumber.php
+++ b/includes/swv/php/rules/maxnumber.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MaxNumberRule extends Rule {
 
-	const rule_name = 'maxnumber';
+	public const rule_name = 'maxnumber';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/mindate.php
+++ b/includes/swv/php/rules/mindate.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MinDateRule extends Rule {
 
-	const rule_name = 'mindate';
+	public const rule_name = 'mindate';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/minfilesize.php
+++ b/includes/swv/php/rules/minfilesize.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MinFileSizeRule extends Rule {
 
-	const rule_name = 'minfilesize';
+	public const rule_name = 'minfilesize';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/minitems.php
+++ b/includes/swv/php/rules/minitems.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MinItemsRule extends Rule {
 
-	const rule_name = 'minitems';
+	public const rule_name = 'minitems';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/minlength.php
+++ b/includes/swv/php/rules/minlength.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MinLengthRule extends Rule {
 
-	const rule_name = 'minlength';
+	public const rule_name = 'minlength';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/minnumber.php
+++ b/includes/swv/php/rules/minnumber.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class MinNumberRule extends Rule {
 
-	const rule_name = 'minnumber';
+	public const rule_name = 'minnumber';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/number.php
+++ b/includes/swv/php/rules/number.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class NumberRule extends Rule {
 
-	const rule_name = 'number';
+	public const rule_name = 'number';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/required.php
+++ b/includes/swv/php/rules/required.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class RequiredRule extends Rule {
 
-	const rule_name = 'required';
+	public const rule_name = 'required';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/requiredfile.php
+++ b/includes/swv/php/rules/requiredfile.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class RequiredFileRule extends Rule {
 
-	const rule_name = 'requiredfile';
+	public const rule_name = 'requiredfile';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/stepnumber.php
+++ b/includes/swv/php/rules/stepnumber.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class StepNumberRule extends Rule {
 
-	const rule_name = 'stepnumber';
+	public const rule_name = 'stepnumber';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/tel.php
+++ b/includes/swv/php/rules/tel.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class TelRule extends Rule {
 
-	const rule_name = 'tel';
+	public const rule_name = 'tel';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/time.php
+++ b/includes/swv/php/rules/time.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class TimeRule extends Rule {
 
-	const rule_name = 'time';
+	public const rule_name = 'time';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/php/rules/url.php
+++ b/includes/swv/php/rules/url.php
@@ -4,7 +4,7 @@ namespace Contactable\SWV;
 
 class URLRule extends Rule {
 
-	const rule_name = 'url';
+	public const rule_name = 'url';
 
 	public function matches( $context ) {
 		if ( false === parent::matches( $context ) ) {

--- a/includes/swv/swv.php
+++ b/includes/swv/swv.php
@@ -143,7 +143,7 @@ class WPCF7_SWV_Schema extends \Contactable\SWV\CompositeRule {
 	/**
 	 * The human-readable version of the schema.
 	 */
-	const version = 'Contact Form 7 SWV Schema 2024-10';
+	public const version = 'Contact Form 7 SWV Schema 2024-10';
 
 
 	/**

--- a/modules/constant-contact/constant-contact.php
+++ b/modules/constant-contact/constant-contact.php
@@ -27,7 +27,7 @@ function wpcf7_constant_contact_register_service() {
  * The WPCF7_Service subclass for Constant Contact.
  */
 class WPCF7_ConstantContact extends WPCF7_Service {
-	const service_name = 'constant_contact';
+	public const service_name = 'constant_contact';
 
 	private static $instance;
 

--- a/modules/stripe/api.php
+++ b/modules/stripe/api.php
@@ -7,10 +7,10 @@
  */
 class WPCF7_Stripe_API {
 
-	const api_version = '2022-11-15';
-	const partner_id = 'pp_partner_HHbvqLh1AaO7Am';
-	const app_name = 'WordPress Contact Form 7';
-	const app_url = 'https://contactform7.com/stripe-integration/';
+	public const api_version = '2022-11-15';
+	public const partner_id = 'pp_partner_HHbvqLh1AaO7Am';
+	public const app_name = 'WordPress Contact Form 7';
+	public const app_url = 'https://contactform7.com/stripe-integration/';
 
 	private $secret;
 


### PR DESCRIPTION
See WordPress coding standards: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#visibility-should-always-be-declared

#23