### PR TITLE
Fix: Improve reliability of `[_url]` special mail tag

### DIFF
--- a/includes/contact-form.php
+++ b/includes/contact-form.php
@@ -702,6 +702,21 @@ class WPCF7_ContactForm {
 		return $class;
 	}
 
+	/**
+	 *
+	 * Returns the URL of the current page.
+	 */
+
+	private function get_page_url() {
+		$url = ( is_ssl ? 'https://' : 'http://' )
+			. wpcf7_superglobal_server( 'HTTP_HOST' )
+			. strtok( wpcf7_superglobal_server( 'REQUEST_URI' ), '?' );
+
+			$url = esc_url_raw( $url );
+
+			return apply_filters( 'wpcf7_page_url', $url );
+	}
+
 
 	/**
 	 * Returns a set of hidden fields.
@@ -713,6 +728,7 @@ class WPCF7_ContactForm {
 			'_wpcf7_locale' => $this->locale(),
 			'_wpcf7_unit_tag' => $this->unit_tag(),
 			'_wpcf7_container_post' => 0,
+			'_wpcf7_posted_from_url' => wpcf7_get_request_uri(),
 			'_wpcf7_posted_data_hash' => '',
 		);
 

--- a/includes/submission.php
+++ b/includes/submission.php
@@ -532,6 +532,15 @@ class WPCF7_Submission {
 	 * Retrieves the request URL of this submission.
 	 */
 	private function get_request_url() {
+		// 1. Prioritize the URL from the hidden field for reliability.
+		$posted_from_url = wpcf7_superglobal_post( '_wpcf7_posted_from_url' );
+
+		if ( $posted_from_url ) {
+			return sanitize_url( $posted_from_url );
+		}
+
+		// 2. Fallback to HTTP_REFERER for REST requests, as it was done before.
+
 		$home_url = untrailingslashit( home_url() );
 
 		if ( self::is_restful() ) {
@@ -542,6 +551,7 @@ class WPCF7_Submission {
 			}
 		}
 
+		// 3. Last resort: build from request URI for non-AJAX submissions.
 		$url = preg_replace( '%(?<!:|/)/.*$%', '', $home_url )
 			. wpcf7_get_request_uri();
 


### PR DESCRIPTION
#### Description:
The `[_url]` special mail tag currently relies on the `HTTP_REFERER` header to determine the submission URL. This header is unreliable and often empty due to modern browser referrer policies (e.g., `Referrer-Policy: no-referrer`), causing the tag to fail.

This PR resolves this by:

1. Adding a hidden `_wpcf7_posted_from_url` field to each form, which captures the current page's URL.
2. Updating the backend logic to prioritize this hidden field. The `HTTP_REFERER` is now used only as a fallback.

This ensures the `[_url]` tag functions correctly and reliably across different browser configurations.

