### PR TITLE
Let `wpcf7_get_contact_form_by_old_id()` explicitly return `null`

### DIFF
--- a/includes/contact-form-functions.php
+++ b/includes/contact-form-functions.php
@@ -19,9 +19,9 @@ function wpcf7_contact_form( $post ) {
  * Searches for a contact form by an old unit ID.
  *
  * @param int $old_id Old unit ID.
- * @return WPCF7_ContactForm Contact form object.
+ * @return WPCF7_ContactForm|null Contact form object, or null if not found.
  */
-function wpcf7_get_contact_form_by_old_id( $old_id ) {
+function wpcf7_get_contact_form_by_old_id( $old_id ): ?WPCF7_ContactForm {
 	$contact_forms = WPCF7_ContactForm::find( array(
 		'meta_query' => array(
 			array(
@@ -33,9 +33,11 @@ function wpcf7_get_contact_form_by_old_id( $old_id ) {
 		'posts_per_page' => 1,
 	) );
 
-	if ( $contact_forms ) {
-		return wpcf7_contact_form( $contact_forms[0] );
+	if ( empty( $contact_forms ) ) {
+		return null;
 	}
+
+	return wpcf7_contact_form( $contact_forms[0] );
 }
 
 


### PR DESCRIPTION
- Make `wpcf7_get_contact_form_by_old_id()` explicitly return `null` (see #1668 for reasoning).
- Fix the `@return` tag to reflect the actual return type.
- Add a return type declaration.