### PR TITLE
Add an override to change the appearance mode of the Turnstile widget

### DIFF
--- a/modules/turnstile/turnstile.php
+++ b/modules/turnstile/turnstile.php
@@ -103,6 +103,8 @@ function wpcf7_turnstile_form_tag_handler( $tag ) {
 			'data-theme' => $tag->get_option( 'theme', '(light|dark|auto)', true ),
 			'data-language' => $tag->get_option( 'language', '[a-z-]{2,5}', true ),
 			'data-tabindex' => $tag->get_option( 'tabindex', 'signed_int', true ),
+			'data-appearance' =>
+				$tag->get_option( 'appearance', '(always|execute|interaction-only)', true ),
 		) )
 	);
 }


### PR DESCRIPTION
Add support for the appearance mode specified here: https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/#appearance-modes
This enable using Turnstile without always showing the widget, which is disruptive in case of forms embedded in the middle of a product page