### PR TITLE
Add Delete row action to contact forms list table

### DIFF
--- a/admin/includes/class-contact-forms-list-table.php
+++ b/admin/includes/class-contact-forms-list-table.php
@@ -181,6 +181,29 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 			) );
 		}
 
+		if ( current_user_can( 'wpcf7_delete_contact_form', $item->id() ) ) {
+			$delete_link = add_query_arg(
+				array(
+					'post' => absint( $item->id() ),
+					'action' => 'delete',
+				),
+				menu_page_url( 'wpcf7', false )
+			);
+
+			$delete_link = wp_nonce_url(
+				$delete_link,
+				'wpcf7-delete-contact-form_' . absint( $item->id() )
+			);
+
+			$actions = array_merge( $actions, array(
+				'delete' => wpcf7_link(
+					$delete_link,
+					__( 'Delete', 'contact-form-7' ),
+					array( 'class' => 'submitdelete' )
+				),
+			) );
+		}
+
 		return $this->row_actions( $actions );
 	}
 


### PR DESCRIPTION
## Summary
This PR adds a Delete link to the row actions that appear when hovering over a contact form title in the admin list table. Previously, users could only delete forms through bulk actions or by navigating to the individual form edit page.

## Changes
- Added Delete row action in `handle_row_actions()` method of `WPCF7_Contact_Form_List_Table` class
- Delete action appears after Duplicate action in hover menu
- Uses `wpcf7_delete_contact_form` capability check
- Protected by `wp_nonce_url()` for security verification
- Styled with `submitdelete` CSS class for consistent red color styling

## User Experience Improvement
- Hover over any form title to see: **Edit | Duplicate | Delete** options
- One-click delete without leaving the list view
- Maintains consistency with WordPress admin interface patterns
- Reduces clicks required for deletion from 3-4 to just 1

## Technical Details
- Leverages existing delete action handler in `admin/admin.php` (no new handler needed)
- No database schema changes required
- Backward compatible with all existing functionality
- Follows WordPress coding standards and security best practices

## Testing
1. Navigate to **Contact → Contact Forms**
2. Hover over any form title
3. Verify "Delete" link appears in red
4. Click Delete and confirm form is deleted
5. Verify capability checks work (user without delete permission shouldn't see link)

## Screenshots
Before: Only Edit and Duplicate actions visible
After: Edit | Duplicate | **Delete** (red) actions visible

<img width="1912" height="440" alt="image" src="https://github.com/user-attachments/assets/dad74012-0c7e-44cf-806b-056a12c99501" />

---

This enhancement improves the user experience by providing quick access to delete functionality directly from the list view, consistent with how WordPress handles other post types.