### PR TITLE
Prevent fatal errors on direct plugin file access

### DIFF
--- a/load.php
+++ b/load.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
 require 'vendor/autoload.php';
 
 require_once WPCF7_PLUGIN_DIR . '/includes/l10n.php';

--- a/wp-contact-form-7.php
+++ b/wp-contact-form-7.php
@@ -12,6 +12,10 @@
  * Requires PHP: 8.3
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
 define( 'WPCF7_VERSION', '6.2-dev' );
 
 define( 'WPCF7_REQUIRED_WP_VERSION', '6.9' );


### PR DESCRIPTION
# Summary

This PR adds a simple guard (`if ( ! defined( 'ABSPATH' ) ) exit;`) to prevent fatal errors when plugin files are accessed directly.

# Background

In the following support forum topic, a fatal error was reported when a plugin file was accessed directly by bots or external requests:

[https://wordpress.org/support/topic/fatal-error-in-line-23/](https://wordpress.org/support/topic/fatal-error-in-line-23/)

Since WordPress core is not loaded in that case, functions like `plugin_basename()` are unavailable and trigger a fatal error.

WordPress plugin best practices also recommend preventing direct file access:

[https://developer.wordpress.org/plugins/plugin-basics/best-practices/#avoiding-direct-file-access](https://developer.wordpress.org/plugins/plugin-basics/best-practices/#avoiding-direct-file-access)

# Reasoning

This is not a critical issue for normal plugin usage, but adding this guard helps avoid unnecessary fatal errors in logs and improves robustness against direct access attempts.

# Note

One thing I could not verify is the execution of:

```
tests/autop/run.php
```

Since it uses the `path_join()` function, it should work correctly as long as WordPress is properly loaded.

