### PR TITLE
Add direct file access protection to all PHP files

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 require_once WPCF7_PLUGIN_DIR . '/admin/includes/admin-functions.php';
 require_once WPCF7_PLUGIN_DIR . '/admin/includes/help-tabs.php';
 require_once WPCF7_PLUGIN_DIR . '/admin/includes/tag-generator.php';

--- a/admin/includes/admin-functions.php
+++ b/admin/includes/admin-functions.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 function wpcf7_current_action() {
 	foreach ( array( 'action', 'action2' ) as $var ) {
 		$action = wpcf7_superglobal_request( $var, null );

--- a/admin/includes/class-contact-forms-list-table.php
+++ b/admin/includes/class-contact-forms-list-table.php
@@ -1,5 +1,7 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
+
 if ( ! class_exists( 'WP_List_Table' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }

--- a/admin/includes/config-validator.php
+++ b/admin/includes/config-validator.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_action( 'wpcf7_admin_menu', 'wpcf7_admin_init_bulk_cv', 10, 0 );
 
 function wpcf7_admin_init_bulk_cv() {

--- a/admin/includes/editor.php
+++ b/admin/includes/editor.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 class WPCF7_Editor {
 
 	private $contact_form;

--- a/admin/includes/welcome-panel.php
+++ b/admin/includes/welcome-panel.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 abstract class WPCF7_WelcomePanelColumn {
 
 	abstract protected function icon();

--- a/includes/block-editor/block-editor.php
+++ b/includes/block-editor/block-editor.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_action(
 	'init',
 	'wpcf7_init_block_editor_assets',

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_filter( 'map_meta_cap', 'wpcf7_map_meta_cap', 10, 4 );
 
 function wpcf7_map_meta_cap( $caps, $cap, $user_id, $args ) {

--- a/includes/config-validator/actions.php
+++ b/includes/config-validator/actions.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_action(
 	'wpcf7_update_option',
 	'wpcf7_config_validator_update_option',

--- a/includes/config-validator/validator.php
+++ b/includes/config-validator/validator.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 require_once path_join( __DIR__, 'form.php' );
 require_once path_join( __DIR__, 'mail.php' );
 require_once path_join( __DIR__, 'messages.php' );

--- a/includes/contact-form-functions.php
+++ b/includes/contact-form-functions.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Contact form helper functions
  */

--- a/includes/contact-form-template.php
+++ b/includes/contact-form-template.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 class WPCF7_ContactFormTemplate {
 
 	public static function get_default( $prop = 'form' ) {

--- a/includes/controller.php
+++ b/includes/controller.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Controller for front-end requests, scripts, and styles
  */

--- a/includes/file.php
+++ b/includes/file.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Validates uploaded files and moves them to the temporary directory.
  *

--- a/includes/form-tags-manager.php
+++ b/includes/form-tags-manager.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Wrapper function of WPCF7_FormTagsManager::add().
  */

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Replaces double line breaks with paragraph elements.
  *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Returns path to a plugin file.
  *

--- a/includes/l10n.php
+++ b/includes/l10n.php
@@ -1,5 +1,7 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
+
 /**
  * Retrieves an associative array of languages to which
  * this plugin is translated.

--- a/includes/mail.php
+++ b/includes/mail.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_filter( 'wpcf7_mail_html_body', 'wpcf7_mail_html_body_autop', 10, 1 );
 
 /**

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_action(
 	'rest_api_init',
 	static function () {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * All the functions and classes in this file are deprecated.
  * You should not use them. The functions and classes will be

--- a/includes/special-mail-tags.php
+++ b/includes/special-mail-tags.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** Special Mail Tags
 ** https://contactform7.com/special-mail-tags/

--- a/includes/swv/script-loader.php
+++ b/includes/swv/script-loader.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_action(
 	'wp_enqueue_scripts',
 	static function () {

--- a/includes/swv/swv.php
+++ b/includes/swv/swv.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Schema-Woven Validation API
  */

--- a/includes/upgrade.php
+++ b/includes/upgrade.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_action( 'wpcf7_upgrade', 'wpcf7_upgrade_58', 10, 2 );
 
 /**

--- a/includes/validation-functions.php
+++ b/includes/validation-functions.php
@@ -1,5 +1,7 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
+
 /**
  * Checks whether a string is a valid NAME token.
  *

--- a/load.php
+++ b/load.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 require 'vendor/autoload.php';
 
 require_once WPCF7_PLUGIN_DIR . '/includes/l10n.php';

--- a/modules/acceptance.php
+++ b/modules/acceptance.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [acceptance]
 **/

--- a/modules/akismet/akismet.php
+++ b/modules/akismet/akismet.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Akismet integration module
  *

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [checkbox], [checkbox*], and [radio]
 **/

--- a/modules/constant-contact/constant-contact.php
+++ b/modules/constant-contact/constant-contact.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Constant Contact module main file
  *

--- a/modules/count.php
+++ b/modules/count.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [count], Twitter-like character count
 **/

--- a/modules/date.php
+++ b/modules/date.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for the following types of tags:
 ** 	[date] and [date*]		# Date

--- a/modules/disallowed-list.php
+++ b/modules/disallowed-list.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_filter( 'wpcf7_spam', 'wpcf7_disallowed_list', 10, 2 );
 
 function wpcf7_disallowed_list( $spam, $submission ) {

--- a/modules/doi-helper.php
+++ b/modules/doi-helper.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Double Opt-In Helper module
  *

--- a/modules/file.php
+++ b/modules/file.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [file] and [file*]
 **/

--- a/modules/flamingo.php
+++ b/modules/flamingo.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** Module for Flamingo plugin.
 ** http://wordpress.org/extend/plugins/flamingo/

--- a/modules/hidden.php
+++ b/modules/hidden.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_action( 'wpcf7_init', 'wpcf7_add_form_tag_hidden', 10, 0 );
 
 function wpcf7_add_form_tag_hidden() {

--- a/modules/listo.php
+++ b/modules/listo.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** Retrieve list data from the Listo plugin.
 ** Listo http://wordpress.org/plugins/listo/

--- a/modules/number.php
+++ b/modules/number.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for the following types of tags:
 ** 	[number] and [number*]		# Number

--- a/modules/quiz.php
+++ b/modules/quiz.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [quiz]
 **/

--- a/modules/really-simple-captcha.php
+++ b/modules/really-simple-captcha.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [captchac] and [captchar]
 **/

--- a/modules/recaptcha/recaptcha.php
+++ b/modules/recaptcha/recaptcha.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * reCAPTCHA module main file
  *

--- a/modules/reflection.php
+++ b/modules/reflection.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Reflection module
  *

--- a/modules/response.php
+++ b/modules/response.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [response]
 **/

--- a/modules/select.php
+++ b/modules/select.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [select] and [select*]
 **/

--- a/modules/sendinblue/contact-form-properties.php
+++ b/modules/sendinblue/contact-form-properties.php
@@ -1,5 +1,6 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
 add_filter(
 	'wpcf7_pre_construct_contact_form_properties',
 	'wpcf7_sendinblue_register_property',

--- a/modules/sendinblue/doi.php
+++ b/modules/sendinblue/doi.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Double Opt-In Helper-related functions
  *

--- a/modules/sendinblue/sendinblue.php
+++ b/modules/sendinblue/sendinblue.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Brevo module main file
  *

--- a/modules/stripe/stripe.php
+++ b/modules/stripe/stripe.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Stripe module main file
  *

--- a/modules/submit.php
+++ b/modules/submit.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [submit]
 **/

--- a/modules/text.php
+++ b/modules/text.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for the following types of tags:
 ** 	[text] and [text*]		# Single-line text

--- a/modules/textarea.php
+++ b/modules/textarea.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 ** A base module for [textarea] and [textarea*]
 **/

--- a/modules/turnstile/turnstile.php
+++ b/modules/turnstile/turnstile.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Turnstile module main file
  */

--- a/wp-contact-form-7.php
+++ b/wp-contact-form-7.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) exit;
 /*
  * Plugin Name: Contact Form 7
  * Plugin URI: https://contactform7.com/


### PR DESCRIPTION
## Summary

Add `if ( ! defined( 'ABSPATH' ) ) exit;` guard after the opening `<?php` tag in all PHP files that were missing it. This resolves the `missing_direct_file_access_protection` error reported by the WordPress Plugin Check (PCP).

## Changes

All 55 PHP files that the PCP audit flagged were missing direct file access protection. Each file now has the ABSPATH check on the first non-blank line after `<?php`.

**Root files:**
- `wp-contact-form-7.php`
- `load.php`

**includes/ (20 files):**
- `functions.php`, `shortcodes.php`, `controller.php`, `formatting.php`, `mail.php`, `rest-api.php`, `file.php`, `validation-functions.php`, `capabilities.php`, `upgrade.php`, `contact-form-functions.php`, `special-mail-tags.php`, `l10n.php`, `form-tags-manager.php`, `contact-form-template.php`
- `swv/script-loader.php`, `swv/swv.php`
- `block-editor/block-editor.php`
- `config-validator/validator.php`, `config-validator/actions.php`

**admin/ (6 files):**
- `admin.php`
- `includes/admin-functions.php`, `includes/editor.php`, `includes/class-contact-forms-list-table.php`, `includes/config-validator.php`, `includes/welcome-panel.php`

**modules/ (27 files):**
- `disallowed-list.php`, `number.php`, `really-simple-captcha.php`, `response.php`, `flamingo.php`, `file.php`, `doi-helper.php`, `hidden.php`, `reflection.php`, `listo.php`, `submit.php`, `acceptance.php`, `date.php`, `count.php`, `textarea.php`, `select.php`, `checkbox.php`, `text.php`, `quiz.php`
- `akismet/akismet.php`, `recaptcha/recaptcha.php`, `sendinblue/sendinblue.php`, `sendinblue/contact-form-properties.php`, `sendinblue/doi.php`, `constant-contact/constant-contact.php`, `stripe/stripe.php`, `turnstile/turnstile.php`

**Before:**
```php
<?php

/**
 * Some docblock...
 */
```

**After:**
```php
<?php

if ( ! defined( 'ABSPATH' ) ) exit;

/**
 * Some docblock...
 */
```

**Why:** WordPress Plugin Check requires all PHP files to prevent direct browser access. Without the guard, files can be loaded directly, potentially leaking information or causing errors.

## Testing

**Test 1: Verify ABSPATH guard presence**
1. Run `grep -rl "if ( ! defined( 'ABSPATH' ) ) exit;" --include="*.php" .` from the plugin root
2. Confirm all 55 files listed above appear in the output

**Test 2: Run PCP**
1. Install and run Plugin Check on the updated plugin
2. Confirm zero `missing_direct_file_access_protection` errors remain

Result: all 55 files now contain the guard, each exactly once.