### PR TITLE
Adds "remove" function to tag generator

### DIFF
--- a/admin/includes/tag-generator.php
+++ b/admin/includes/tag-generator.php
@@ -63,6 +63,25 @@ class WPCF7_TagGenerator {
 		return true;
 	}
 
+	/**
+	 * Removes a form-tag generator instance.
+	 */
+	public function remove( $id ) {
+		$id = trim( $id );
+
+		if (
+			'' === $id or
+			! wpcf7_is_name( $id ) or
+			! array_key_exists( $id, $this->panels )
+		) {
+			return false;
+		}
+
+		unset( $this->panels[$id] );
+
+		return true;
+	}
+
 
 	/**
 	 * Renders form-tag generator calling buttons.


### PR DESCRIPTION
Adds a `remove` function to tag generator in order to remove panels by id. Extends support for third party plugin developers to have more control over which buttons and panels get generated in by means other than directly overwriting with the existing `add` function or sloppily hiding buttons with CSS or JS.