### PR TITLE
Use str_starts_with() and str_contains()

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -113,7 +113,7 @@ add_action(
 );
 
 function wpcf7_admin_enqueue_scripts( $hook_suffix ) {
-	if ( false === strpos( $hook_suffix, 'wpcf7' ) ) {
+	if ( ! str_contains( $hook_suffix, 'wpcf7' ) ) {
 		return;
 	}
 

--- a/includes/contact-form-template.php
+++ b/includes/contact-form-template.php
@@ -137,7 +137,7 @@ class WPCF7_ContactFormTemplate {
 		$sitename = wp_parse_url( network_home_url(), PHP_URL_HOST );
 		$sitename = strtolower( $sitename );
 
-		if ( 'www.' === substr( $sitename, 0, 4 ) ) {
+		if ( str_starts_with( $sitename, 'www.' ) ) {
 			$sitename = substr( $sitename, 4 );
 		}
 

--- a/includes/file.php
+++ b/includes/file.php
@@ -200,7 +200,7 @@ function wpcf7_acceptable_filetypes( $types = 'default', $format = 'regex' ) {
 	if ( 'attr' === $format or 'attribute' === $format ) {
 		$types = array_map(
 			static function ( $type ) {
-				if ( false === strpos( $type, '/' ) ) {
+				if ( ! str_contains( $type, '/' ) ) {
 					return sprintf( '.%s', trim( $type, '.' ) );
 				} elseif ( preg_match( '%^([a-z]+)/[*]$%i', $type, $matches ) ) {
 					if (
@@ -224,7 +224,7 @@ function wpcf7_acceptable_filetypes( $types = 'default', $format = 'regex' ) {
 	} elseif ( 'regex' === $format ) {
 		$types = array_map(
 			static function ( $type ) {
-				if ( false === strpos( $type, '/' ) ) {
+				if ( ! str_contains( $type, '/' ) ) {
 					return preg_quote( trim( $type, '.' ) );
 				} elseif ( $type = wpcf7_convert_mime_to_ext( $type ) ) {
 					return $type;

--- a/includes/form-tag.php
+++ b/includes/form-tag.php
@@ -386,7 +386,7 @@ class WPCF7_FormTag implements ArrayAccess {
 		foreach ( $options as $opt ) {
 			$opt = sanitize_key( $opt );
 
-			if ( 'user_' === substr( $opt, 0, 5 ) and is_user_logged_in() ) {
+			if ( str_starts_with( $opt, 'user_' ) and is_user_logged_in() ) {
 				$primary_props = array( 'user_login', 'user_email', 'user_url' );
 				$opt = in_array( $opt, $primary_props, true ) ? $opt : substr( $opt, 5 );
 

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -76,7 +76,7 @@ function wpcf7_sanitize_query_var( $text ) {
 	$text = wp_unslash( $text );
 	$text = wp_check_invalid_utf8( $text );
 
-	if ( false !== strpos( $text, '<' ) ) {
+	if ( str_contains( $text, '<' ) ) {
 		$text = wp_pre_kses_less_than( $text );
 		$text = wp_strip_all_tags( $text );
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -22,7 +22,7 @@ function wpcf7_plugin_path( $path = '' ) {
 function wpcf7_plugin_url( $path = '' ) {
 	$url = plugins_url( $path, WPCF7_PLUGIN );
 
-	if ( is_ssl() and 'http:' === substr( $url, 0, 5 ) ) {
+	if ( is_ssl() and str_starts_with( $url, 'http:' ) ) {
 		$url = 'https:' . substr( $url, 5 );
 	}
 

--- a/includes/html-formatter.php
+++ b/includes/html-formatter.php
@@ -158,9 +158,9 @@ class WPCF7_HTMLFormatter {
 				);
 			}
 
-			if ( '<!' === substr( $next_tag, 0, 2 ) ) {
+			if ( str_starts_with( $next_tag, '<!' ) ) {
 				$next_tag_type = self::comment;
-			} elseif ( '</' === substr( $next_tag, 0, 2 ) ) {
+			} elseif ( str_starts_with( $next_tag, '</' ) ) {
 				$next_tag_type = self::end_tag;
 			} else {
 				$next_tag_type = self::start_tag;

--- a/includes/mail.php
+++ b/includes/mail.php
@@ -388,7 +388,7 @@ class WPCF7_Mail {
 			$uploaded_files = $submission->uploaded_files();
 
 			foreach ( (array) $uploaded_files as $name => $paths ) {
-				if ( false !== strpos( $template, "[{$name}]" ) ) {
+				if ( str_contains( $template, "[{$name}]" ) ) {
 					$attachments = array_merge( $attachments, (array) $paths );
 				}
 			}
@@ -397,7 +397,7 @@ class WPCF7_Mail {
 		foreach ( explode( "\n", $template ) as $line ) {
 			$line = trim( $line );
 
-			if ( '' === $line or '[' === substr( $line, 0, 1 ) ) {
+			if ( '' === $line or str_starts_with( $line, '[' ) ) {
 				continue;
 			}
 

--- a/modules/really-simple-captcha.php
+++ b/modules/really-simple-captcha.php
@@ -405,7 +405,7 @@ function wpcf7_captcha_tmp_url() {
 function wpcf7_captcha_url( $filename ) {
 	$url = path_join( wpcf7_captcha_tmp_url(), $filename );
 
-	if ( is_ssl() and 'http:' === substr( $url, 0, 5 ) ) {
+	if ( is_ssl() and str_starts_with( $url, 'http:' ) ) {
 		$url = 'https:' . substr( $url, 5 );
 	}
 

--- a/modules/sendinblue/sendinblue.php
+++ b/modules/sendinblue/sendinblue.php
@@ -177,7 +177,7 @@ function wpcf7_sendinblue_collect_parameters() {
 	foreach ( (array) $submission->get_posted_data() as $name => $val ) {
 		$name = strtoupper( $name );
 
-		if ( 'YOUR-' === substr( $name, 0, 5 ) ) {
+		if ( str_starts_with( $name, 'YOUR-' ) ) {
 			$name = substr( $name, 5 );
 		}
 


### PR DESCRIPTION
Replaces 5 `strpos()` checks with `str_contains()`, and 8 `substr()` prefix comparisons with `str_starts_with()`, across `admin/`, `includes/`, and `modules/`.

This improves readability (`! str_contains( $hook_suffix, 'wpcf7' )` states the intent directly) and removes some magic numbers (`'<!' === substr( $next_tag, 0, 2 )` -> `str_starts_with( $next_tag, '<!' )`).

No behavior change.

### Possible follow-up

In some cases a magic number remains, e.g.:

```php
if ( str_starts_with( $sitename, 'www.' ) ) {
	$sitename = substr( $sitename, 4 );
}
```

and could be replaced with:

```php
if ( str_starts_with( $sitename, 'www.' ) ) {
	$sitename = substr( $sitename, strlen( 'www.' ) );
}
```

further increasing readability - in contrast to `4`, `strlen( 'www.' )` states the intent directly.

Happy to fold this into this PR, or leave it for a separate one.
